### PR TITLE
Fix the ARBUS 200 issue showing "None Software Engineering"

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -367,12 +367,12 @@ def profile_page(profile_user_id):
     def get_latest_program_year_id(uc_dict_list, user_id):
         latest_term_uc = None
         for uc_dict in uc_dict_list:
-            if uc_dict['user_id'] != user_id:
+            if (uc_dict['user_id'] != user_id or
+                    uc_dict['term_id'] > LAST_TERM_ID):
                 continue
             elif not latest_term_uc:
                 latest_term_uc = uc_dict
-            elif (uc_dict['term_id'] > latest_term_uc['term_id']
-                    and uc_dict['term_id'] <= LAST_TERM_ID):
+            elif uc_dict['term_id'] > latest_term_uc['term_id']:
                 latest_term_uc = uc_dict
 
         if latest_term_uc:


### PR DESCRIPTION
Caused by a shortlisted UC hitting this case:

```
elif not latest_term_uc:
   latest_term_uc = uc_dict
```

Probably wasn't happening for other shortlisted UC's because it has to be the 
very first UC in the uc_dict_list to cause this problem.

Bug report:
https://uwflow.uservoice.com/admin/tickets/26/?q=assignee%3Ame+status%3Aopen
