### PR TITLE
Foreground the local server for make local

### DIFF
--- a/local_server.sh
+++ b/local_server.sh
@@ -27,7 +27,7 @@ echo "Starting flask server"
 FLASK_CONFIG=../config/flask_dev.py \
   PARENT_DIR=$(dirname `pwd`) \
   PYTHONPATH="${PARENT_DIR}" \
-  python server/server.py &
+  python server/server.py
 
 # Only exit on terminate or interrupt signal
 while true; do


### PR DESCRIPTION
Stop running the flask server in the background so we can use the python 
debugger. With it running in the background, the debugger automatically exits 
because it isn't interactive. With this running in the foreground, using the 
debugging by injecting

```
import ipdb; ipdb.set_trace()
```

Works fine (you'll need to pip install ipdb).

Ctrl-C will still kill the flask server and all the other local server 
processes.
