### PR TITLE
Stop showing friends who have taken the course in the preview

### DIFF
--- a/server/profile.py
+++ b/server/profile.py
@@ -287,7 +287,7 @@ def render_profile_page(profile_user_id, current_user=None):
     # Convert courses to dicts
     course_dict_list, user_course_dict_list, user_course_list = (
             m.Course.get_course_and_user_course_dicts(
-                transcript_courses, current_user, include_friends=own_profile))
+                transcript_courses, current_user))
     course_dicts = {}
     for course_dict in course_dict_list:
         course_dicts[course_dict['id']] = course_dict

--- a/server/static/js/course.js
+++ b/server/static/js/course.js
@@ -310,10 +310,10 @@ function(RmcBackbone, $, _, _s, ratings, __, util, jqSlide, _prof, toastr,
 
     render: function() {
       var domId = 'course-view-' + this.courseModel.get('user_course_id');
+
       this.$el.attr('id', domId).html(this.template({
         course: this.courseModel.toJSON(),
         user_course: this.userCourse,
-        //star_uc: window.pageData.ownProfile ? this.userCourse : this.profileUserCourse
         profile_user_course: this.profileUserCourse,
         other_profile: this.otherProfile,
         mode: this.courseModel.getInteractMode()
@@ -323,13 +323,6 @@ function(RmcBackbone, $, _, _s, ratings, __, util, jqSlide, _prof, toastr,
 
       var overallRating = this.courseModel.getOverallRating();
       this.ratingBoxView = new ratings.RatingBoxView({ model: overallRating });
-
-      var friendUserCourses = this.courseModel.get('friend_user_courses');
-      if (friendUserCourses) {
-        this.sampleFriendsView = new SampleFriendsView({
-          friendUserCourses: friendUserCourses
-        });
-      }
 
       this.updateAddCourseTooltip();
       this.updateRemoveCourseTooltip();

--- a/server/templates/course.html
+++ b/server/templates/course.html
@@ -27,7 +27,6 @@
 
     <div class="rating-box-placeholder"></div>
     <div class="voting-placeholder"></div>
-    <div class="sample-friends-placeholder"></div>
     <div class="review-stars-placeholder"></div>
     <% if (profile_user_course && profile_user_course.hasTaken()) { %>
     <% } %>


### PR DESCRIPTION
This drops the time from page request to transcript rendered from ~5500ms to ~4000ms. More importantly, this drops the page freeze time down considerably - before we had about a 2000ms page stall, now it's closer to 1000-1200ms, which still isn't great. The perf gains might be more significant on mobile, since that 2000ms page stall was likely much longer on mobile than desktop.

This obviously removes functionality however - this removes the preview of which friends have taken courses both in your profile view and in the course search view.

A better solution would definitely be to make a lot more of this stuff async, but UserCourses are definitely one of the bottlenecks, both on the server side and on the clientside.
