### PR TITLE
Fix schedule share bar to not wrap on small widths

### DIFF
--- a/server/static/sass/_schedule.scss
+++ b/server/static/sass/_schedule.scss
@@ -262,27 +262,32 @@ $toolbarBg: #FAFAFA;
   border-top: 1px solid $wellBorderColor;
   @include border-radius(0 0 4px 4px);
 
+  .form-inline {
+    display: table;
+
+    > .cell {
+      display: table-cell;
+      white-space: nowrap;
+      padding-left: 10px;
+
+      &:first-child {
+        padding-left: 0;
+      }
+    }
+  }
+
   .share-label {
-    padding-left: 6px;
-    padding-right: 6px;
+    vertical-align: middle;
+    margin: auto;
+  }
+
+  .link-box-container {
+    width: 100%;
   }
 
   .link-box {
-    // TODO(david): Stretch box to take up more horizontal space if available
-    width: 270px;
-  }
-
-  .print-schedule-btn {
-    float: right;
-    margin-left: 10px;
-  }
-
-  .reimport-btn {
-    float: right;
-    margin-left: 10px;
-  }
-
-  .export-btn-group {
-    float: right;
+    width: 100%;
+    @include box-sizing(border-box);
+    height: 31px;
   }
 }

--- a/server/templates/schedule.html
+++ b/server/templates/schedule.html
@@ -92,25 +92,23 @@
 {# TODO(Sandy): consider generalizing this if we need it later #}
 {% call macros.us_template('schedule-share-tpl') %}
 <div class="form-inline">
-  <button class="facebook-btn btn btn-info">
-    <i class="icon-share"></i>&nbsp;
-    Share on Facebook
-  </button>
-  <label class="share-label">or share this link:</label>
-  <input type="url" class="link-box input-small" value="<%- url %>">
-  <a href="<%- printUrl %>" target="_blank" class="print-schedule-btn btn">
-    <i class="icon-print"></i>&nbsp;
-    Print
-  </a>
-  <button class="reimport-btn btn">
-    <i class="icon-refresh"></i>&nbsp;
-    Reimport
-  </button>
-  <div class="export-btn-group btn-group">
+  <span class="cell">
+    <button class="facebook-btn btn btn-info">
+      <i class="icon-share"></i>&nbsp;
+      Share on Facebook
+    </button>
+  </span>
+  <span class="cell">
+    <label class="share-label">or share this link:</label>
+  </span>
+  <span class="cell link-box-container">
+    <input type="url" class="link-box input-small" value="<%- url %>">
+  </span>
+  <div class="cell export-btn-group btn-group">
     <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
       <i class="icon-external-link"></i>&nbsp;
       Export
-      <span class="caret"></span>
+      &nbsp;<span class="caret"></span>
     </a>
     <ul class="dropdown-menu">
       <li class="google-calendar-export-btn">
@@ -126,6 +124,18 @@
       </li>
     </ul>
   </div>
+  <span class="cell">
+    <button class="reimport-btn btn">
+      <i class="icon-refresh"></i>&nbsp;
+      Reimport
+    </button>
+  </span>
+  <span class="cell">
+    <a href="<%- printUrl %>" target="_blank" class="print-schedule-btn btn">
+      <i class="icon-print"></i>&nbsp;
+      Print
+    </a>
+  </span>
 </div>
 {% endcall %}
 


### PR DESCRIPTION
During our CUSEC demo, I noticed that the "export" button overflowed to the next line. In fact, this starts happening on any screen widths < 1300px.

This fixes that, and also gets the link box to stretch to take up all available space. Also refactors the CSS/HTML to get gutter widths to be more consistent and have only one (well, two) occurrence of that width.

It helps a bit to view the code diff with `?w=1` to ignore whitespace, though GitHub still doesn't show the move properly: https://github.com/divad12/rmc/pull/29/files?w=1
### Browser width 1436px (full-width on my MBPr)

Before:

![image](https://f.cloud.github.com/assets/159687/1982314/ed7660ca-83f8-11e3-8973-90ba32c70f21.png)

After:

![image](https://f.cloud.github.com/assets/159687/1982316/f91420d4-83f8-11e3-8b26-68742bc7ea5b.png)
### Browser width 1311px

Before:

![image](https://f.cloud.github.com/assets/159687/1982324/163753f2-83f9-11e3-823c-f4ed0022014c.png)

After:

![image](https://f.cloud.github.com/assets/159687/1982326/31032cf6-83f9-11e3-9329-bf6110cd62c7.png)
### Browser width 1161px

Before:

![image](https://f.cloud.github.com/assets/159687/1982328/661aef50-83f9-11e3-823f-b79fb63da172.png)

After:

![image](https://f.cloud.github.com/assets/159687/1982333/7ab31230-83f9-11e3-9f47-f71508468074.png)
