### PR TITLE
Add course reviews to `/api/v1/courses/:id` endpoint

### DIFF
--- a/server/api/v1.py
+++ b/server/api/v1.py
@@ -15,7 +15,12 @@ def get_course(course_id):
     if not course:
         return api_util.api_not_found('Course %s not found. :(' % course_id)
 
-    return api_util.jsonify(course.to_dict())
+    current_user = view_helpers.get_current_user()
+    course_reviews = course.get_reviews(current_user)
+
+    return api_util.jsonify(dict(course.to_dict(), **{
+        'reviews': course_reviews,
+    }))
 
 
 @app.route('/api/v1/courses/<string:course_id>/professors', methods=['GET'])

--- a/server/server.py
+++ b/server/server.py
@@ -261,19 +261,7 @@ def course_page(course_id):
         user_dicts[current_user.id] = current_user.to_dict(
                 include_course_ids=True)
 
-    def tip_from_uc(uc_dict):
-        # TODO(david): Don't instantiate a class just to call a method on it
-        return m.CourseReview(**uc_dict['course_review']).to_dict(current_user,
-                uc_dict['user_id'])
-
-    tip_dict_list = [tip_from_uc(uc_dict) for uc_dict in user_course_dict_list
-            if len(uc_dict['course_review']['comment']) >=
-                m.review.CourseReview.MIN_REVIEW_LENGTH]
-
-    # Try to not show older reviews, if we have enough results
-    date_getter = lambda review: review['comment_date']
-    tip_dict_list = util.publicly_visible_ratings_and_reviews_filter(
-            tip_dict_list, date_getter, util.MIN_NUM_REVIEWS)
+    tip_dict_list = course.get_reviews(current_user, user_course_list)
 
     rmclogger.log_event(
         rmclogger.LOG_CATEGORY_IMPRESSION,

--- a/shared/util.py
+++ b/shared/util.py
@@ -170,7 +170,7 @@ def freshness_filter(objs, to_date_func, num_days=None):
 
 def publicly_visible_ratings_and_reviews_filter(
         objs, to_date_func, min_num_objs, num_days=None):
-    """Return a fitlered list of objs that can be public facing.
+    """Return a filtered list of ratings and reviews that can be public facing.
 
     Return the "freshest" objects, but try to return at least min_num_objs.
     """


### PR DESCRIPTION
As suggested by @jswu in https://github.com/divad12/rmc/pull/39
