### PR TITLE
Use a custom JSON encoder for API responses

### DIFF
--- a/server/api/api_util.py
+++ b/server/api/api_util.py
@@ -92,12 +92,13 @@ def jsonify(data):
     """Returns a flask.Response of data, JSON-stringified.
 
     This is basically Flask's jsonify
-    (https://github.com/mitsuhiko/flask/blob/master/flask/json.py), but using
-    our own JSON dumps method, which plugs an XSS hole and knows how to encode
-    Mongo ObjectIds and datetimes.
+    (https://github.com/mitsuhiko/flask/blob/master/flask/json.py), but plugs
+    an XSS hole and knows how to encode Mongo ObjectIds and datetimes.
     """
     indent = None if flask.request.is_xhr else 2
 
-    return flask.current_app.response_class(
-            json.dumps(data, indent=indent, cls=ApiJsonEncoder),
+    jsonified = json.dumps(data, indent=indent, cls=ApiJsonEncoder)
+    jsonified_safe = jsonified.replace('</', '<\\/')
+
+    return flask.current_app.response_class(jsonified_safe,
             mimetype='application/json')

--- a/server/api/v1.py
+++ b/server/api/v1.py
@@ -97,19 +97,13 @@ def get_course_users(course_id):
               "friend_ids": [],
               "program_name": "Software Engineering",
               "course_history": [],
-              "id": {
-                "$oid": "50a532518aedf423ac645891"
-              }
+              "id": "50a532518aedf423ac645891"
             }
           ],
           "term_users": [
             {
               "term_id": "2013_01",
-              "user_ids": [
-                {
-                  "$oid": "50a532518aedf423ac645891"
-                }
-              ],
+              "user_ids": [ "50a532518aedf423ac645891" ],
               "term_name": "Winter 2013"
             }
           ]
@@ -278,15 +272,15 @@ def get_user_courses(user_id):
               "prereqs": "Open only to students in Chemical Engineering",
               "overall": { "count": 131, "rating": 0.7099236641221374 },
               "professor_ids": [ "hyuk_sang_park" ],
-              "user_course_id": { "$oid": "50a9c41c8aedf423ac6458b1" },
+              "user_course_id": "50a9c41c8aedf423ac6458b1",
               "id": "che102",
               "description": "Chemical principles blah blah blah..."
             }
           ],
           "user_courses": [
             {
-              "id": { "$oid": "50a9c41c8aedf423ac6458b1" },
-              "user_id": { "$oid": "50a532518aedf423ac645891" },
+              "id": "50a9c41c8aedf423ac6458b1",
+              "user_id": "50a532518aedf423ac645891",
               "course_id": "che102",
               "term_name": "Fall 2009",
               "term_id": "2009_09",
@@ -299,7 +293,7 @@ def get_user_courses(user_id):
                   { "rating": null, "name": "easiness" },
                   { "rating": null, "name": "interest" }
                 ],
-                "comment_date": { "$date": 1355447961031 },
+                "comment_date": 1355447961031,
                 "privacy": "friends"
               },
               "professor_review": {
@@ -308,7 +302,7 @@ def get_user_courses(user_id):
                   { "rating": 1.0, "name": "clarity" },
                   { "rating": null, "name": "passion" }
                 ],
-                "comment_date": { "$date": 1355447928463 },
+                "comment_date": 1355447928463,
                 "privacy": "friends"
               },
               "program_year_id": "1A"


### PR DESCRIPTION
... that encodes datetimes and BSON ObjectIds in a sane, unnested way.

Also see discussion from https://github.com/divad12/rmc/pull/52

Before: `https://uwflow.com/api/v1/courses/cs241/sections`

``` json
[
  {
    "last_updated": {
      "$date": 1392786056000
    },
    "term_id": "2014_01",
    "meetings": [
      {
        "building": "MC",
        "is_tba": false,
        "room": "2038",
        "end_date": null,
        "days": [
          "M",
          "W",
          "F"
        ],
        "start_seconds": 30600,
        "prof_id": "nomair_ahmed_naeem",
        "end_seconds": 33600,
        "is_cancelled": false,
        "start_date": null,
        "is_closed": false
      }
    ],
    "section_type": "LEC",
    "id": {
      "$oid": "528095dd8c43724eaa85498a"
    },
    "note": "Choose TUT section for Related 1.",
    "class_num": "5576",
    "waiting_total": 0,
    "enrollment_total": 67,
    "units": 0.5,
    "section_num": "001",
    "enrollment_capacity": 86,
    "waiting_capacity": 0,
    "campus": "UW U",
    "course_id": "cs241"
  }
]
```

After: `http://localhost:5000/api/v1/courses/cs241/sections`

``` json
[
  {
    "note": "Choose TUT section for Related 1.",
    "units": 0.5,
    "last_updated": 1384455834000,
    "class_num": "5576",
    "term_id": "2014_01",
    "meetings": [
      {
        "building": "MC",
        "is_tba": false,
        "room": "2038",
        "end_date": null,
        "days": [
          "M",
          "W",
          "F"
        ],
        "start_seconds": 30600,
        "prof_id": "nomair_ahmed_naeem",
        "end_seconds": 33600,
        "is_cancelled": false,
        "start_date": null,
        "is_closed": false
      }
    ],
    "section_type": "LEC",
    "campus": "UW U",
    "waiting_total": 0,
    "enrollment_capacity": 73,
    "section_num": "001",
    "enrollment_total": 73,
    "course_id": "cs241",
    "waiting_capacity": 0,
    "id": "527fda7e78d6fe74e8d25885"
  }
]
```

Test plan: Hit all endpoints, ensured everything still worked.
