### PR TITLE
Change all references to old repos to point to the new UWFlow org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third_party/rmc_linter"]
 	path = third_party/rmc_linter
-	url = https://github.com/phleet/rmc-linter.git
+	url = https://github.com/UWFlow/rmc-linter.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ For the most part, you can just stick to the conventions of the surrounding
 code.
 
 [See our style guide for language-specific
-guidelines.](https://github.com/divad12/rmc/wiki/Flow-Style-Guide)
+guidelines.](https://github.com/UWFlow/rmc/wiki/Flow-Style-Guide)
 
 ## Mock-ups
 

--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ Here's what an example session might look like:
 ## Contributing
 
 When you're ready to contribute, take a look at [the contributing
-guidelines](https://github.com/divad12/rmc/blob/master/CONTRIBUTING.md) and our
-[style guide](https://github.com/divad12/rmc/wiki/Flow-Style-Guide).
+guidelines](https://github.com/UWFlow/rmc/blob/master/CONTRIBUTING.md) and our
+[style guide](https://github.com/UWFlow/rmc/wiki/Flow-Style-Guide).

--- a/aws_setup/setup.sh
+++ b/aws_setup/setup.sh
@@ -64,7 +64,7 @@ scp ~/.ssh/id_dsa* rmc:~/.ssh/
 EOF
 
 echo "Syncing rmc code base"
-git clone git@github.com:divad12/rmc.git || ( cd rmc && git pull )
+git clone git@github.com:UWFlow/rmc.git || ( cd rmc && git pull )
 
 echo "Copying dotfiles"
 for i in $CONFIG_DIR/dot_*; do

--- a/server/static/js/main.js
+++ b/server/static/js/main.js
@@ -207,7 +207,7 @@ function(_s, util, moment, Backbone, __, __, toastr, _points,
   // So manually check if domready has occurred, and if it has execute
   // right away. In IE, gotta wait for state === 'complete' since
   // state === 'interactive' could fire before dom is ready. See
-  // https://github.com/divad12/rmc/commit/56af16db497db5b8d4e210e784e9f63051fcce32
+  // https://github.com/UWFlow/rmc/commit/56af16db497db5b8d4e210e784e9f63051fcce32
   // for more info.
   var state = document.readyState;
   if (document.attachEvent ? state === 'complete' : state !== 'loading' ) {


### PR DESCRIPTION
To update your repo fully assuming you're still running on `divad12/rmc`, you need to run this:

```
git remote set-url origin git@github.com:UWFlow/rmc.git
git pull
git submodule sync
```
