### PR TITLE
Turn on CSRF protection

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -2,8 +2,6 @@ import base64
 import datetime
 import hashlib
 import itertools
-import random
-import string
 import time
 import uuid
 
@@ -22,11 +20,6 @@ from rmc.shared import util
 
 
 PROMPT_TO_REVIEW_DELAY_DAYS = 60
-
-
-# TODO(jlfwong): Use a random generator that's cryptographically secure instead
-def generate_secret_id(size=9, chars=string.ascii_uppercase + string.digits):
-    return ''.join(random.choice(chars) for x in range(size))
 
 
 class User(me.Document):
@@ -485,7 +478,7 @@ class User(me.Document):
     def get_secret_id(self):
         # TODO(jlfwong): This is possibly a race condition...
         if self.secret_id is None:
-            self.secret_id = generate_secret_id()
+            self.secret_id = util.generate_secret_id()
             self.save()
 
         return self.secret_id

--- a/server/static/js/main.js
+++ b/server/static/js/main.js
@@ -103,6 +103,14 @@ window._ = _;
 window.$ = $;
 window.jQuery = $;
 
+// Add a CSRF token to the headers for all ajax requests being sent out by
+// jQuery.
+$.ajaxSetup({
+  headers: {
+    'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
+  }
+});
+
 require(['ext/underscore.string', 'util', 'rmc_moment',
     'ext/backbone', 'ext/bootstrap', 'ext/cookie', 'ext/toastr',
     'points', 'user', 'facebook', 'work_queue'],

--- a/server/templates/base_page.html
+++ b/server/templates/base_page.html
@@ -10,6 +10,7 @@
     <meta property="og:title" content="Flow">
     <meta property="og:description" content="Plan your UW courses with friends in mind.">
     <meta property="og:image" content="https://uwflow.com/static/img/logo/flow_og_200x200.png">
+    <meta content="{{ csrf_token() }}" name="csrf-token" />
     {% block head_tags %}
     {% endblock %}
 

--- a/shared/util.py
+++ b/shared/util.py
@@ -1,6 +1,8 @@
 import datetime
 import logging
 import math
+import random
+import string
 import traceback
 
 import pytz
@@ -185,3 +187,8 @@ def publicly_visible_ratings_and_reviews_filter(
         results = objs[0:min_num_objs]
 
     return results
+
+
+# TODO(jlfwong): Use a random generator that's cryptographically secure instead
+def generate_secret_id(size=9, chars=string.ascii_uppercase + string.digits):
+    return ''.join(random.choice(chars) for x in range(size))


### PR DESCRIPTION
Flow has been CSRF vulnerable since forever ago :smile: 

Here's an example CSRF attack that when loaded in a user's browser while they're logged into flow will add the Security course to their shortlist.

``` html
<!-- uwflow-xsrf.html -->
<style type="text/css">
iframe {
    position: absolute;
    top: 0;
    left: -9000px;
}
</style>
<h1>Nothing Suspicious Here</h1>
<iframe src="uwflow-xsrf-frame.html"></iframe>
```

``` html
<!-- uwflow-xsrf-frame.html -->
<script>
window.onload = function() {
    var form = document.getElementById("frm");
    form.submit();
};
</script>
<form action="http://localhost:5000/api/user/add_course_to_shortlist" method="POST" id="frm">
    <input type="hidden" name="course_id" value="cs458" />
    <input type="submit" />
</form>
```
## Test Plan

Loaded the above POC exploit before this patch, saw that it added the security course.

Applied patch, deleted account using `tools/devshell.py`, recreated account, ensured that I was still able to import transcript and add ratings to courses.

Loaded the above POC again, saw that it hit a 403 by looking at the network panel in the chrome devtools.
