### PR TITLE
Regenerate opendata API keys, move to secrets

### DIFF
--- a/data/crawler.py
+++ b/data/crawler.py
@@ -13,12 +13,12 @@ import urllib2
 import lxml.html
 from lxml.html import soupparser
 
+import rmc.shared.secrets as s
 import rmc.shared.constants as c
 import rmc.models as m
 import mongoengine as me
 
 
-API_UWATERLOO_API_KEY = 'ead3606c6f096657ebd283b58bf316b6'
 API_UWATERLOO_V2_URL = 'https://api.uwaterloo.ca/v2'
 
 # TODO(david): Convert this file to use OpenData v2 (v1 is now deprecated and
@@ -250,7 +250,7 @@ def get_opendata_courses():
             courses[dep].add(matches[0][1])
 
     errors = []
-    api_key = API_UWATERLOO_API_KEY
+    api_key = s.OPEN_DATA_API_KEY
     bad_courses = 0
     bad_course_names = set()
     good_courses = 0
@@ -314,7 +314,7 @@ def get_opendata_courses():
 
 
 def get_opendata_exam_schedule():
-    api_key = API_UWATERLOO_API_KEY
+    api_key = s.OPEN_DATA_API_KEY
     current_term_id = m.Term.get_current_term_id()
     current_quest_termid = m.Term.get_quest_id_from_term_id(current_term_id)
     url = ('http://api.uwaterloo.ca/v2/terms/{term_id}/examschedule.json'
@@ -407,7 +407,7 @@ def get_subject_sections_from_opendata(subject, term):
     url = ('{api_url}/terms/{term}/{subject}/schedule.json'
             '?key={api_key}'.format(
                 api_url=API_UWATERLOO_V2_URL,
-                api_key=API_UWATERLOO_API_KEY,
+                api_key=s.OPEN_DATA_API_KEY,
                 subject=subject,
                 term=term,
     ))

--- a/shared/secrets.py.example
+++ b/shared/secrets.py.example
@@ -21,6 +21,10 @@ FLASK_SECRET_KEY = 'likeafireworksshow'
 # Shh, don't let the NSA know we have this.
 US_NUCLEAR_LAUNCH_CODE = '00000000'
 
+# NOTE: This key is only for local usage. The API key used in production is
+# different.
+OPEN_DATA_API_KEY = '5da84ced3d60901f54666c2f338c908d'
+
 # This is a fake Flickr API key - if you need to use the Flickr API (just used
 # for downloading kittens at the moment), generate one yourself.
 # FLICKR_API_KEY = 'loveyouifyouloveacarfortheroadtrips'


### PR DESCRIPTION
Procedure:
1. Generated 2 new API keys - one to stick in the secrets.py.example for use by new devs, and another that I'll install myself in production
2. Have @KartikTalwar remove rate limiting on the new secret production API key
3. Modify the `shared/secrets.py` on production to add the new `OPEN_DATA_API_KEY` with the new secret production key
4. Merge this pull request and deploy
5. Have @KartikTalwar delete or at least add rate limiting back to `ead3606c6f096657ebd283b58bf316b6` (the old production API key)

After this lands, everyone will need to add the following to their local copy of `shared/secrets.py`.

```
OPEN_DATA_API_KEY = '5da84ced3d60901f54666c2f338c908d'
```
