### PR TITLE
"Search courses" --> "Explore courses"

### DIFF
--- a/server/templates/base_page.html
+++ b/server/templates/base_page.html
@@ -189,7 +189,7 @@
 
         <ul class="nav pull-right">
           <li class="{{ 'active' if nav_item == 'courses' else '' }}">
-            <a class="nav-item" href="/courses"><i class="icon-reorder"></i> Search courses</a>
+            <a class="nav-item" href="/courses"><i class="icon-reorder"></i> Explore courses</a>
           </li>
 
           <li class="divider-vertical"></li>

--- a/server/templates/search_page.html
+++ b/server/templates/search_page.html
@@ -12,10 +12,10 @@
   <link rel="prerender" href="/profile">
 {% endblock %}
 
-{% block page_title %}Search courses{% endblock %}
+{% block page_title %}Explore courses{% endblock %}
 
 {% block header %}
-  {{ macros.page_title("Search Courses") }}
+  {{ macros.page_title("Explore courses") }}
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
The main motivation for this change is to make it more likely for someone to
want to click on this nav heading if they just landed on the homepage,
especially if they don't have a particular course in mind to want to search for.

This is exactly the type of thing that would be great to A/B test, but we don't
get enough traffic to yield a meaningful result within a short time frame.

![image](https://f.cloud.github.com/assets/159687/2291365/7016efa4-a03c-11e3-87b2-0a01ab4be8e7.png)

(I'll remove the annoying text shadow in another PR.)
