### PR TITLE
Remove annoying text shadow from nav bar

### DIFF
--- a/server/static/sass/_base.scss
+++ b/server/static/sass/_base.scss
@@ -135,6 +135,8 @@ a:hover {
 }
 
 .navbar {
+  $font-color: #555;
+
   z-index: 200;
   background: rgb(250, 250, 250);
   @include box-shadow(0 1px 4px rgba(0, 0, 0, 0.2));
@@ -144,6 +146,9 @@ a:hover {
     position: relative;
 
     .brand {
+      color: $font-color;
+      text-shadow: none;
+
       .logo {
         position: absolute;
         width: 75px;
@@ -186,8 +191,6 @@ a:hover {
 
     .user-points {
       margin-left: 5px;
-      //font-weight: bold;
-      //font-size: 16px;
       @include transition(all 0.3s ease-out);
     }
 
@@ -211,6 +214,8 @@ a:hover {
       line-height: 25px;
       .nav-item {
         border-top: 3px solid transparent;
+        color: $font-color;
+        text-shadow: none;
         @include transition(all 0.3s ease-out);
 
         &:hover {


### PR DESCRIPTION
As promised in #84 ....

Before:

![image](https://f.cloud.github.com/assets/159687/2291393/d8355a76-a03c-11e3-8281-8b59e7596c29.png)

After:

![image](https://f.cloud.github.com/assets/159687/2291387/c09ba0fa-a03c-11e3-9da3-1dbab45e3b21.png)
