### PR TITLE
Order terms in section table in chronological order.

### DIFF
--- a/server/templates/about_page.html
+++ b/server/templates/about_page.html
@@ -249,6 +249,15 @@
         contributions
       </a>
     </li>
+    <li>
+      <a target="_blank" href="https://github.com/klistwan/">
+        Konrad Listwan-Ciesielski
+      </a> &mdash;
+      <a target="_blank"
+          href="https://github.com/UWFlow/rmc/commits/master?author=klistwan">
+        contributions
+      </a>
+    </li>
   </ul>
 
   <h1 class="sponsors-heading">Thank you sponsors</h1>

--- a/server/templates/section.html
+++ b/server/templates/section.html
@@ -1,11 +1,12 @@
 {% import 'macros.html' as macros %}
 
 {% call macros.us_template('sections-collection-tpl') %}
-<% _.each(Object.keys(terms).sort(), function(termId) { %>
+<% _.each(_.keys(terms).sort(), function(termId) { %>
   <h2 class="sections-term-heading"><%- humanizeTermId(termId) %></h2>
-  <% if (terms[termId][0].has('note')) { %>
+  <% var term = terms[termId]; %>
+  <% if (term[0].has('note')) { %>
     <p>
-      <strong>Please note:</strong> <%- terms[termId][0].get('note') %>
+      <strong>Please note:</strong> <%- term[0].get('note') %>
     </p>
   <% } %>
   <table class="sections-table table table-bordered table-rounded">
@@ -21,7 +22,7 @@
       </tr>
     </thead>
     <tbody>
-      <% _.each(terms[termId], function(section) { %>
+      <% _.each(term, function(section) { %>
         <tr class="section-<%- sectionTypeToCssClass(section.get('section_type'))
                 %> <%- sectionFullCssClass(section) %>">
           <td>
@@ -108,9 +109,9 @@
   </table>
   <small class="last-updated">
     Last updated
-    <%- moment(terms[termId][0].get('last_updated')).fromNow() %> from
+    <%- moment(term[0].get('last_updated')).fromNow() %> from
 
-    <% var courseParts = splitCourseId(terms[termId][0].get('course_id')); %>
+    <% var courseParts = splitCourseId(term[0].get('course_id')); %>
     <% var questId = termIdToQuestId(termId); %>
 
     <a href="http://www.adm.uwaterloo.ca/cgi-bin/cgiwrap/infocour/salook.pl?level=under&sess=<%- questId %>&subject=<%- courseParts[0] %>&cournum=<%- courseParts[1] %>"


### PR DESCRIPTION
Fixes: https://github.com/UWFlow/rmc/issues/67

The issue was that we were running _.each on terms, which was just an object so sometimes it would order the terms correctly, and other times not.

I changed it so we iterate on a list of sorted termIds, so it'll always stay chronologically.

Before:
![image](https://f.cloud.github.com/assets/808263/2302100/c8ef677a-a16b-11e3-925b-09efcca71b52.png)

After:
![image](https://f.cloud.github.com/assets/808263/2302114/47a733c2-a16c-11e3-8bbd-af192c86560c.png)
