### PR TITLE
Added 'apt-get install ruby-dev' to linux-setup.sh

### DIFF
--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -54,7 +54,7 @@ install_packages() {
         git \
         python-setuptools python-pip python-dev \
         libxml2-dev libxslt-dev \
-        ruby rubygems \
+        ruby rubygems ruby-dev \
         nodejs \
         redis-server \
         mongodb-10gen \


### PR DESCRIPTION
Without 'apt-get install ruby-dev', there were problems with the installation
on Linux.
