### PR TITLE
Don't linkify profs in section table on search page

### DIFF
--- a/server/static/js/course.js
+++ b/server/static/js/course.js
@@ -450,6 +450,8 @@ function(RmcBackbone, $, _, _s, ratings, __, util, jqSlide, _prof, toastr,
           this.userCourse.hasTaken() &&
           this.canShowAddReview;
       this.courseView = attributes.courseView;  // optional
+      this.shouldlinkifySectionProfs = (
+          attributes.shouldLinkifySectionProfs || false);
 
       this.ratingsView = new ratings.RatingsView({
         ratings: this.courseModel.get('ratings'),
@@ -470,7 +472,8 @@ function(RmcBackbone, $, _, _s, ratings, __, util, jqSlide, _prof, toastr,
 
       if (this.courseModel.has('sections')) {
         this.sectionCollectionView = new _section.SectionCollectionView({
-          collection: this.courseModel.get('sections')
+          collection: this.courseModel.get('sections'),
+          shouldlinkifyProfs: this.shouldLinkifySectionProfs
         });
       }
 

--- a/server/static/js/course_page.js
+++ b/server/static/js/course_page.js
@@ -17,7 +17,8 @@ function($, course, tookThis, user, tips, prof, _exam, ratings, user_course, _re
 
   var courseInnerView = new course.CourseInnerView({
     courseModel: courseModel,
-    userCourse: userCourse
+    userCourse: userCourse,
+    shouldLinkifySectionProfs: true
   });
   $('#course-inner-container').html(courseInnerView.render().el);
   courseInnerView.animateBars();

--- a/server/static/js/section.js
+++ b/server/static/js/section.js
@@ -30,8 +30,9 @@ function(RmcBackbone, $, _, _s) {
   var SectionCollectionView = RmcBackbone.View.extend({
     className: 'sections-collection',
 
-    initialize: function() {
+    initialize: function(options) {
       this.template = _.template($('#sections-collection-tpl').html());
+      this.shouldLinkifyProfs = options.shouldLinkifyProfs;
     },
 
     render: function() {
@@ -53,7 +54,8 @@ function(RmcBackbone, $, _, _s) {
           // ONLNR ONLINE
           var onlinePattern = /ONLN.? ONLINE/;
           return onlinePattern.test(section.get('campus')) ? 'N/A' : 'TBA';
-        }
+        },
+        shouldLinkifyProfs: this.shouldLinkifyProfs
       }));
       return this;
     }

--- a/server/templates/section.html
+++ b/server/templates/section.html
@@ -98,11 +98,15 @@
             <% _.each(section.get('meetings'), function(meeting) { %>
               <p>
                 <% if (meeting.prof_id) { %>
-                  <% var profName = humanizeProfId(meeting.prof_id) %>
-		  <a href="#<%- normalizeProfName(profName) %>">
-		    <%- profName %>
-		  </a>   
-		<% } %>
+                  <% var profName = humanizeProfId(meeting.prof_id); %>
+                    <% if (shouldLinkifyProfs) { %>
+                      <a href="#<%- normalizeProfName(profName) %>">
+                        <%- profName %>
+                      </a>
+                    <% } else { %>
+                      <%- profName %>
+                    <% } %>
+                  <% } %>
               </p>
             <% }); %>
           </td>


### PR DESCRIPTION
Fixes #102

Currently there are broken links on the search page ("Explore courses") due
to #98. This is the simplest fix -- just don't link up those profs. Ideally,
we make those links look like '/course/econ101#l_smith' so that a user could
click directly to the prof review on the course details page, but due to the
way we async-load prof reviews, this won't actually work.

Search page:

![image](https://f.cloud.github.com/assets/159687/2307194/d853aec8-a2a2-11e3-8aff-1037ab5f7c2d.png)

Details page:

![image](https://f.cloud.github.com/assets/159687/2307201/ebd99da4-a2a2-11e3-95c1-46937bb36d69.png)
