### PR TITLE
Add `screenshot_url` field to /api/v1/user/schedule

### DIFF
--- a/server/api/v1.py
+++ b/server/api/v1.py
@@ -8,6 +8,7 @@ import flask
 import rmc.models as m
 import rmc.server.api.api_util as api_util
 import rmc.server.view_helpers as view_helpers
+import rmc.shared.schedule_screenshot as schedule_screenshot
 import rmc.shared.facebook as facebook
 
 
@@ -240,9 +241,11 @@ def get_user(user_id):
 def get_user_schedule(user_id):
     user = _get_user_require_auth(user_id)
     schedule_item_dict_list = user.get_schedule_item_dicts()
+    screenshot_url = schedule_screenshot.get_screenshot_url(user)
 
     return api_util.jsonify({
-        'schedule': schedule_item_dict_list
+        'schedule': schedule_item_dict_list,
+        'screenshot_url': screenshot_url,
     })
 
 


### PR DESCRIPTION
This just uses the screenshots we took for Facebook thumbnails. It also happens that these would be convenient to use for our Android app.

Though, we'll probably want to make some changes to make these work better for the Android app:
- [ ] take screenshots of all non-empty weeks
- [x] get rid of the next/prev week controls
- [ ] change aspect ratio (make image less fat)
- [ ]      (not related to screenshots, but) query params to this API endpoint to specify week

`http://localhost:5000/api/v1/user/schedule`:

``` json
{
  "screenshot_url": "http://localhost:5000/static/schedules/98f3f7c43ecdce4469ec3251137c6992.png", 
  "schedule": [
    {
      "end_date": 1362507600000, 
      "prof_id": "oleg_michailovich", 
      "course_id": "ece402", 
      "id": "50f51edf8aedf4e11ba0da11", 
      "building": "M3", 
      "room": "1006", 
      "term_id": "2013_01", 
      "section_type": "SEM", 
      "section_num": "003", 
      "class_num": "4479", 
      "start_date": 1362504600000
    }
  ]
}
```

`http://localhost:5000/static/schedules/98f3f7c43ecdce4469ec3251137c6992.png`:

![image](https://f.cloud.github.com/assets/159687/2338361/2ad502e4-a4a8-11e3-8566-b7be7b957fe3.png)

cc @jasperfung
