### PR TITLE
Return the CSRF token from /api/v1/login/facebook

### DIFF
--- a/server/api/v1.py
+++ b/server/api/v1.py
@@ -164,6 +164,9 @@ def login_facebook():
     Responds with the session cookie via the `set-cookie` header on success.
     Send the associated cookie for all subsequent API requests that accept
     user authentication.
+
+    Also returns the CSRF token, which must be sent as the value of the
+    "X-CSRF-Token" header for all non-GET requests.
     """
     # Prevent a CSRF attack from replacing a logged-in user's account with the
     # attacker's.
@@ -190,7 +193,12 @@ def login_facebook():
                 'Create an account at uwflow.com.' % fbid)
 
     view_helpers.login_as_user(user)
-    return api_util.jsonify({'message': 'Logged in user %s' % user.name})
+    csrf_token = view_helpers.generate_csrf_token()
+
+    return api_util.jsonify({
+        'message': 'Logged in user %s' % user.name,
+        'csrf_token': csrf_token,
+    })
 
 
 ###############################################################################

--- a/server/server.py
+++ b/server/server.py
@@ -114,18 +114,12 @@ def csrf_protect():
         # We intentionally don't invalidate CSRF tokens after a single use to
         # enable multiple AJAX requests originating from the page load to all
         # work off the same CSRF token.
-        token = flask.session.get('_csrf_token', None)
+        token = flask.session.get(view_helpers.SESSION_COOKIE_KEY_CSRF, None)
         if not token or token != req.headers.get('X-CSRF-Token'):
             flask.abort(403)
 
 
-def generate_csrf_token():
-    if '_csrf_token' not in flask.session:
-        flask.session['_csrf_token'] = util.generate_secret_id(size=15)
-    return flask.session['_csrf_token']
-
-
-app.jinja_env.globals['csrf_token'] = generate_csrf_token
+app.jinja_env.globals['csrf_token'] = view_helpers.generate_csrf_token
 
 
 # TODO(Sandy): Unused right now, but remove in a separate diff for future

--- a/server/view_helpers.py
+++ b/server/view_helpers.py
@@ -10,9 +10,11 @@ import urllib
 
 import rmc.models as m
 import rmc.shared.constants as c
+import rmc.shared.util as util
 
 
 SESSION_COOKIE_KEY_USER_ID = 'user_id'
+SESSION_COOKIE_KEY_CSRF = '_csrf_token'
 
 
 _redis_instance = redis.StrictRedis(host=c.REDIS_HOST,
@@ -148,3 +150,10 @@ def redirect_to_profile(user):
             user.id, flask.request.query_string), 302)
     else:
         return flask.redirect('/profile/%s' % user.id, 302)
+
+
+def generate_csrf_token():
+    if SESSION_COOKIE_KEY_CSRF not in flask.session:
+        flask.session[SESSION_COOKIE_KEY_CSRF] = util.generate_secret_id(
+                size=15)
+    return flask.session[SESSION_COOKIE_KEY_CSRF]


### PR DESCRIPTION
@phleet review please?
## Test plan

Ran `curl -d 'fb_access_token=thispathisreckless' -i http://localhost:5000/api/v1/login/facebook`, ensured response's cookie value contains the encrypted CSRF token and the response body contains the unencrypted CSRF token.

Also clicked around on web app and made sure things weren't broken.
