### PR TITLE
Update welcome email to emphasize calendar export

### DIFF
--- a/emails/active/welcome_email.py
+++ b/emails/active/welcome_email.py
@@ -20,7 +20,7 @@ def html_body_renderer(user):
     <p>We noticed that you recently signed up for <a href="https://uwflow.com">UW Flow</a>!</p>"""
 
     if not user.has_schedule:
-        welcome_email_body += """<p>Did you know that you can <a href="https://uwflow.com/profile?import-schedule=1">upload your class schedule</a>? This lets you export it to Google Calendar and iCal.</p>
+        welcome_email_body += """<p>Did you know that you can <a href="https://uwflow.com/profile?import-schedule=1">upload your class schedule</a>? This lets you export it to Google Calendar and iCal, and share it with friends.</p>
 
         <img src="https://uwflow.com/static/img/class-schedule-screenshot-nov-2013.png">"""
 


### PR DESCRIPTION
@mduan Review please?

Here's our old welcome email:

![image](https://f.cloud.github.com/assets/159687/2496121/61b1c226-b311-11e3-842a-b99cfe5d1827.png)

Now that we have calendar export, this updates it to emphasize that feature.
- Change blurb to say "Did you know that you can [upload your class schedule](https://uwflow.com/profile?import-schedule=1)? This lets you export it to Google Calendar and iCal."
- Update screenshot to this one:

![image](https://uwflow.com/static/img/class-schedule-screenshot-nov-2013.png)

Not tested yet.
