### PR TITLE
Fix two issues with Quest schedule parsing

### DIFF
--- a/server/static/js/schedule.js
+++ b/server/static/js/schedule.js
@@ -872,7 +872,7 @@ function(RmcBackbone, $, _, _s, _bootstrap, _user, _course, _util, _facebook,
       var locationRe = /([\-\w ,]+)/;
       // Apparently, it's possible to have mutiple profs (on separate lines):
       // e.g. Behrad Khamesee,\nJan Huissoon
-      var profRe = /([\-\w ,\r\n]+)/;
+      var profRe = /([\-\w .,\r\n]+)/;
       // The day can appear in the following formats:
       // - '01/23/2013'
       // - '23/01/2013'


### PR DESCRIPTION
Two fixes:
1. Quest adds yet another date format: `YYYY/MM/DD`. Yayyy!!! So now we support all of the following formats:
   - `YYYY/MM/DD`
   - `MM/DD/YYYY`
   - `DD/MM/YYYY`
   - `YYYY-MM-DD`
   
   Here's to hoping they don't add `YYYY/DD/MM`. If they do, I'll drink coffee!
2. Allow periods in professor names.
# Test plan

Here's a schedule (from a cat) that failed to parse completely (no schedule items extracted) before, but now parses correctly:

```
GO!

Meredith Swift

My Academics            Course Selection (Undergrad only)           Enroll          GO Pass

my class schedule           add             drop            swap            component swap          appointments            search for classes

My Class Schedule

List View

Weekly Calendar View

Select Display Option

Change Term

Spring 2014 | Undergraduate | University of Waterloo

NE 232 - Quantum Mechanics

Status  Units   Grading     Grade
Enrolled

0.50

Numeric Grading Basis

Class Nbr   Section     Component   Days & Times    Room    Instructor  Start/End Date
2926

001

LEC

MWF 10:30 - 11:20

QNC 2502

David D.G Cory

2014/05/05 - 2014/07/30


W 11:30 - 12:20

QNC 2502

David D.G Cory

2014/05/14 - 2014/05/14

W 11:30 - 12:20

QNC 2502

Staff

2014/05/28 - 2014/05/28

Exam Information
```

Also verified that my Quest schedule, which correctly parsed before, still correctly parses after this change.

Yes, it would be great to have testing infrastructure for our schedule parsing JS. But for now, I have to start studying for our SE 465 Testing final tomorrow, ironically.
