### PR TITLE
Refactored get_current_term_exams to group sections.

### DIFF
--- a/data/processor.py
+++ b/data/processor.py
@@ -312,20 +312,23 @@ def group_similar_exam_sections(exam_sections):
             examschedule.json endpoint.
 
     Returns a consolidated list of sections in the same format, where each item
-        has a unique date/time/location."""
-
+        has a unique date/time/location.
+    """
     def order_sections(sections):
         sections_list = sorted(sections.split(', '))
         return ', '.join(sections_list)
 
+    def is_similar(first, second):
+        return (first.get('start_time') == second.get('start_time') and
+                first.get('end_time') == second.get('end_time') and
+                first.get('date') == second.get('date') and
+                first.get('location') == second.get('location'))
+
     different_sections = []
     for section in exam_sections:
-        similar_exams = [s for s in different_sections if (
-                section.get('start_time') == s.get('start_time') and
-                section.get('end_time') == s.get('end_time') and
-                section.get('date') == s.get('date') and
-                section.get('location') == s.get('location'))]
-        if len(similar_exams):
+        similar_exams = [s for s in different_sections if 
+                is_similar(s, section)]
+        if similar_exams:
             similar_exams[0]['section'] += ', ' + section.get('section')
         else:
             different_sections.append(section)

--- a/data/processor_test.py
+++ b/data/processor_test.py
@@ -1,0 +1,90 @@
+import unittest
+
+from processor import group_similar_exam_sections
+
+
+class ExamTest(unittest.TestCase):
+    def test_group_similar_exam_sections_one_section(self):
+        self.assertEquals(group_similar_exam_sections(
+            [
+                {
+                    'start-time': '4:00 PM',
+                    'end-time': '7:00 PM',
+                    'location': 'DC',
+                    'section': '007',
+                }
+            ]), 
+            [
+                {
+                    'start-time': '4:00 PM',
+                    'end-time': '7:00 PM',
+                    'location': 'DC',
+                    'section': '007',
+                }
+            ]
+        )
+
+    def test_group_similar_exam_sections_two_sections(self):
+        self.assertEquals(group_similar_exam_sections(
+            [
+                {
+                    'start-time': '4:00 PM',
+                    'end-time': '7:00 PM',
+                    'location': 'DC',
+                    'section': '007',
+                },
+                {
+                    'start-time': '4:00 PM',
+                    'end-time': '7:00 PM',
+                    'location': 'DC',
+                    'section': '001',
+                }
+            ]), 
+            [
+                {
+                    'start-time': '4:00 PM',
+                    'end-time': '7:00 PM',
+                    'location': 'DC',
+                    'section': '001, 007',
+                }
+            ]
+        )
+
+    def test_group_different_exam_sections_three_sections(self):
+        self.assertEquals(group_similar_exam_sections(
+            [
+                {
+                    'start-time': '4:00 PM',
+                    'end-time': '7:00 PM',
+                    'location': 'DC',
+                    'section': '007',
+                },
+                {
+                    'start-time': '4:00 PM',
+                    'end-time': '7:00 PM',
+                    'location': 'DC',
+                    'section': '001',
+                },
+                {
+                    'start-time': '4:00 PM',
+                    'end-time': '7:00 PM',
+                    'location': 'MC',
+                    'section': '117',
+                }
+            ]), 
+            [
+                {
+                    'start-time': '4:00 PM',
+                    'end-time': '7:00 PM',
+                    'location': 'DC',
+                    'section': '001, 007',
+                },
+                {
+                    'start-time': '4:00 PM',
+                    'end-time': '7:00 PM',
+                    'location': 'MC',
+                    'section': '117',
+                }
+            ]
+        )
+


### PR DESCRIPTION
Closes issue #99 by fixing the problem when courses are imported from OpenData but before they are saved to Mongo, and closes PR #96. 

Sections for each subject are ordered before being saved, so that it's easier to find any one section on the table.

Tested by running:

`PYTHONPATH=.. python data/crawler.py opendata_exam_schedule`  and then
`PYTHONPATH=.. python data/processor.py exams`

to ensure that the exams are grouped together appropriately. 
