### PR TITLE
Python lint fixes

### DIFF
--- a/data/evals/conversion/eng.py
+++ b/data/evals/conversion/eng.py
@@ -48,7 +48,7 @@ def import_engineering_critiques(input_file):
             # FIXME(Sandy): Normalize prof names
             prof_names = get_prof_names(prof_name)
             prof = m.Professor(**prof_names)
-            # Note: Manually verified that .save() will not erase existing 
+            # Note: Manually verified that .save() will not erase existing
             # fields that are not set on save (ie. ratings)
             prof.save()
             professor_id = prof.id

--- a/data/evals/scraper.py
+++ b/data/evals/scraper.py
@@ -86,7 +86,7 @@ for course in courses:
 
         result_length = len(result)
         if result_length >= 230:
-            # TODO(Sandy): Remember to scrape individual terms for courses 
+            # TODO(Sandy): Remember to scrape individual terms for courses
             # with > 10 results
             print "More than 10 results"
             err_file.write(course + " got more than 10 results (" +
@@ -136,6 +136,6 @@ for course in courses:
     else:
         print "No results"
 
-    
+
 file.close()
 err_file.close()

--- a/data/processor.py
+++ b/data/processor.py
@@ -304,7 +304,7 @@ def import_reviews():
 
 
 def group_similar_exam_sections(exam_sections):
-    """Groups together exam sections that have the same date, time, 
+    """Groups together exam sections that have the same date, time,
        and location.
 
     Args:
@@ -326,7 +326,7 @@ def group_similar_exam_sections(exam_sections):
 
     different_sections = []
     for section in exam_sections:
-        similar_exams = [s for s in different_sections if 
+        similar_exams = [s for s in different_sections if
                 is_similar(s, section)]
         if similar_exams:
             similar_exams[0]['section'] += ', ' + section.get('section')

--- a/data/processor_test.py
+++ b/data/processor_test.py
@@ -13,7 +13,7 @@ class ExamTest(unittest.TestCase):
                     'location': 'DC',
                     'section': '007',
                 }
-            ]), 
+            ]),
             [
                 {
                     'start-time': '4:00 PM',
@@ -39,7 +39,7 @@ class ExamTest(unittest.TestCase):
                     'location': 'DC',
                     'section': '001',
                 }
-            ]), 
+            ]),
             [
                 {
                     'start-time': '4:00 PM',
@@ -71,7 +71,7 @@ class ExamTest(unittest.TestCase):
                     'location': 'MC',
                     'section': '117',
                 }
-            ]), 
+            ]),
             [
                 {
                     'start-time': '4:00 PM',
@@ -87,4 +87,3 @@ class ExamTest(unittest.TestCase):
                 }
             ]
         )
-

--- a/models/points.py
+++ b/models/points.py
@@ -6,4 +6,3 @@ class PointSource(object):
     PROFESSOR_COMMENT = 50
     PROFESSOR_RATING = 10
     SHARE_PROFESSOR_REVIEW = 50
-

--- a/models/user_schedule_item.py
+++ b/models/user_schedule_item.py
@@ -97,4 +97,3 @@ class FailedScheduleItem(me.Document):
     def __repr__(self):
         return "<FailedScheduleItem: %s, %s, %s, %s %s, %s-%s>" % (
             self.user_id, self.course_id, self.parsed_date)
-

--- a/server/server.py
+++ b/server/server.py
@@ -1045,7 +1045,7 @@ def user_course():
         uc.professor_id = prof_id
 
         # TODO(Sandy): Have some kind of sanity check for professor names.
-        # Don't allow ridiculousness like "Santa Claus", "aksnlf", 
+        # Don't allow ridiculousness like "Santa Claus", "aksnlf",
         # "swear words"
         if m.Professor.objects(id=prof_id).count() == 0:
             first_name, last_name = m.Professor.guess_names(new_prof_name)

--- a/shared/tasks.py
+++ b/shared/tasks.py
@@ -44,5 +44,3 @@ def render_schedule_screenshot(url_to_render, screenshot_filepath):
         else:
             logging.error('Rendering %s failed (returned %d)',
                     screenshot_filepath, retcode)
-
-

--- a/test/lib/flask_test_case.py
+++ b/test/lib/flask_test_case.py
@@ -28,4 +28,3 @@ class FlaskTestCase(fixtures_test_case.FixturesTestCase):
 
     def assertJsonResponse(self, resp, expected):
         self.assertEqual(deunicode(json.loads(resp.data)), expected)
-

--- a/test/lib/model_test_case.py
+++ b/test/lib/model_test_case.py
@@ -32,4 +32,3 @@ class ModelTestCase(unittest.TestCase):
     def tearDownClass(cls):
         me.connection.disconnect()
         ModelTestCase._drop_test_database()
-


### PR DESCRIPTION
Some python lint fixes to confirm with changes to pep8 in https://github.com/UWFlow/rmc-linter/pull/1.

One thing I'd still like to lint for (if possible) is indentation, but it doesn't seem possible with pep8 for pyflakes.

Partially fixes #106.
