### PR TITLE
Fix cutoff text for exams in schedules

### DIFF
--- a/server/static/sass/_schedule.scss
+++ b/server/static/sass/_schedule.scss
@@ -58,11 +58,11 @@ $toolbarBg: #FAFAFA;
 
   .section-info {
     color: #666;
+    white-space: initial;
 
     .course-code {
       font-weight: bold;
       color: $textColor;
-      white-space: normal;
     }
   }
 


### PR DESCRIPTION
Enabled text wrapping on the course code. This may require a bit more
playing with to make it look nicer, but it appears to do the trick.

Closes #156
