### PR TITLE
Use short program name for search bar suggestions

### DIFF
--- a/server/api/v1.py
+++ b/server/api/v1.py
@@ -577,7 +577,7 @@ def search_unified():
             friends = user.get_friends()
             friend_dicts = [{
                 'label': f.name,
-                'program': f.program_name,
+                'program': f.short_program_name,
                 'type': 'friend',
                 'id': f.id,
                 'pic': f.profile_pic_urls['square'],


### PR DESCRIPTION
... so that we have "Software Engineering" instead of
"Software Engineering, Honours, Co-operative Program"
