### PR TITLE
Link to prof pages from course pages

### DIFF
--- a/server/static/sass/_prof_info.scss
+++ b/server/static/sass/_prof_info.scss
@@ -13,6 +13,15 @@
     .prof-name {
       line-height: 24px;
       margin-bottom: 25px;
+
+      .prof-link {
+        text-decoration: none;
+        color: $textColor;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
     }
 
     .dept-name {

--- a/server/templates/prof.html
+++ b/server/templates/prof.html
@@ -4,7 +4,9 @@
   <img width="150" height="150"
     class="prof-picture img-polaroid" src="<%- pictureUrl %>"></img>
   <div id="<%- normalizeProfName(name) %>" class="prof-info">
-    <h3 class="prof-name"><%- name %></h3>
+    <h3 class="prof-name">
+      <a href="/professor/<%- id %>" class="prof-link"><%- name %></a>
+    </h3>
     <dl class="dl-horizontal">
       <dt>Email</dt>
       <dd>Coming soon...</dd>


### PR DESCRIPTION
Makes the existing prof's names on the courses page clickable and links to their page. 

Fixes #183 

![prof_link_from_courses](https://cloud.githubusercontent.com/assets/2644780/3565711/770b61ce-0acb-11e4-9221-f8446670495d.png)
