### PR TITLE
Partial Facebook login support for email users

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -401,33 +401,45 @@ def login_with_facebook():
             },
         )
     else:
-        # New user. Sign up with their Facebook info
+        # New user, or existing email logins user.
         now = datetime.now()
-        user_obj = {
-            'email': req.form.get('email'),
+        email = req.form.get('email')
+        user_data = {
             'fb_access_token': fb_access_token,
             'fb_access_token_expiry_date': fb_access_token_expiry_date,
             'fbid': fbid,
-            'first_name': req.form.get('first_name'),
             'friend_fbids': flask.json.loads(req.form.get('friend_fbids')),
             'gender': req.form.get('gender'),
-            'join_date': now,
-            'join_source': m.User.JoinSource.FACEBOOK,
-            'last_name': req.form.get('last_name'),
             'last_visited': now,
-            'middle_name': req.form.get('middle_name'),
         }
 
-        referrer_id = req.form.get('referrer_id')
-        if referrer_id:
-            try:
-                user_obj['referrer_id'] = bson.ObjectId(referrer_id)
-            except bson.errors.InvalidId:
-                pass
+        user = m.User.objects(email=email).first() if email else None
+        if user:
+            # Update existing account with Facebook data
+            referrer_id = None
+            for k, v in user_data.iteritems():
+                user[k] = v
+            user.save()
+        else:
+            # Create an account with their Facebook data
+            user_data.update({
+                'email': email,
+                'first_name': req.form.get('first_name'),
+                'join_date': now,
+                'join_source': m.User.JoinSource.FACEBOOK,
+                'last_name': req.form.get('last_name'),
+                'middle_name': req.form.get('middle_name'),
+            })
 
-        # Create the user
-        user = m.User(**user_obj)
-        user.save()
+            referrer_id = req.form.get('referrer_id')
+            if referrer_id:
+                try:
+                    user_data['referrer_id'] = bson.ObjectId(referrer_id)
+                except bson.errors.InvalidId:
+                    pass
+
+            user = m.User(**user_data)
+            user.save()
 
         # Authenticate
         view_helpers.login_as_user(user)


### PR DESCRIPTION
Adds support to allow users who have already signed up using their email to also log in with their Facebook. Currently, we return a 500 if a user tries to login with a Facebook account that has the same email as their Flow account.

Fixed up the code from #181 to ignore `None` emails (e.g. create a new account for them). We know that this will be a new user because:
1. If a user already signed in with Facebook before, then their fbid would have matched earlier on in the function
2. A user cannot create account with a `None` email

Lines 406 and 416 were added in this change compared to #181.
### Why does this happen

Emails are sometimes not returned by the API for a variety of reasons including signing up with only phone number or not having confirmed their email. More info here: https://developers.facebook.com/bugs/298946933534016
### Testing
1. Set the `email` to `None` right before that block of code
2. Log in with a test Facebook user

Before this change, the user would be logged in as some existing user. After the change, a new account is created. This was verified by checking the user objects in the devshell.

Also retested the case where the test Facebook user already has an account with their email, but no fbid associated with that account. Verified that after signing in with Facebook, the old account is used for the current session and gets assigned the new fbid (instead of throwing a NotUniqueError like it does now).
