### PR TITLE
Focus the schedule dialog box when it pops up

### DIFF
--- a/server/static/js/schedule.js
+++ b/server/static/js/schedule.js
@@ -692,6 +692,8 @@ function(RmcBackbone, $, _, _s, _bootstrap, _user, _course, _util, _facebook,
       this.$el.html(this.template({}));
       this.$('.schedule-input-placeholder')
         .replaceWith(this.scheduleInputView.render().el);
+      // Set a tabIndex so that it can have focus, and thus be dismissed by esc
+      this.$('.schedule-input-modal').prop('tabIndex', '0');
       return this;
     }
   });


### PR DESCRIPTION
Gives the schedule dialog box a tabIndex of 0 so that
it can be focused, and then focuses it.
The call to focus is in render, since I couldn't figure out
how to place it in initialize, since not enough is loaded yet.
That might be a horrible mistake, please fix that.

Now the dialog box closes when esc is pressed, like normal.

Fixes #196
