### PR TITLE
Changed 'https' to 'http' in Google Calender ics export link

### DIFF
--- a/server/static/js/schedule.js
+++ b/server/static/js/schedule.js
@@ -836,8 +836,10 @@ function(RmcBackbone, $, _, _s, _bootstrap, _user, _course, _util, _facebook,
   };
 
   var getICalScheduleUrl = function() {
-    return _util.getSiteBaseUrl() +
-        '/schedule/ical/' + window.pageData.profileUserSecretId + ".ics";
+    var baseURL = _util.getSiteBaseUrl().replace('https', 'http');
+
+    return baseURL +
+        '/schedule/ical/' + window.pageData.profileUserSecretId + '.ics';
   };
 
   return {


### PR DESCRIPTION
Currently, exporting to Google Calendar gives the error message:

> This email address isn't associated with an active Google Calendar account: https://uwflow.com/schedule/ical/XXXXXXXXX.ics. Please check the email address and try again.

Google Calendar seems to have issues with https sites.
Changing the 'https' to 'http' in 'https://uwflow.com/schedule/ical/XXXXXXXXX.ics' will make it work. Thus, the quickest fix is to simply serve the ics url as http instead.

This may pose some security issues though, which might need to be discussed. 

Relevant Stack Overflow questions: 
[Link to add ics to Google Calendar stopped working](http://stackoverflow.com/questions/12563178/link-to-add-ics-to-google-calendar-stopped-working,) 
[Google Calendar can't subscribe to icalendar feed over https?](http://stackoverflow.com/questions/12824727/google-calendar-cant-subscribe-to-icalendar-feed-over-https)
