### PR TITLE
Added Python tests to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,17 @@
+services:
+  - mongodb
+
 install:
-  - npm install mocha-phantomjs phantomjs
+  - ./linux-setup.sh
+  - sudo ./setup.sh
+  - sudo npm install mocha-phantomjs phantomjs
+
+before_script:
+  - sudo rm /var/lib/mongodb/mongod.lock
+  - sudo service mongodb restart
+  - sleep 15
 
 script:
   - ./js_test.sh
+  - source ~/.virtualenv/rmc/bin/activate
+  - make test


### PR DESCRIPTION
This will run the command `PYTHONPATH=.. nosetests -a '!slow'` and make sure it exits with status code 0, in addition to the JS tests already there. Note that the 15 second sleep is a Travis CI is to fix a known issue with Mongo. You can check https://travis-ci.org/JGulbronson/rmc/builds to see that they're passing. 
