### PR TITLE
→ instead of > in step 1 description on the onboarding page

### DIFF
--- a/server/templates/onboarding_page.html
+++ b/server/templates/onboarding_page.html
@@ -24,8 +24,8 @@
           <p class="step">
             Log in to <a target="_blank"
               href="https://quest.pecs.uwaterloo.ca/psp/SS/?cmd=login">
-              Quest</a> &gt; My Academics &gt; Unofficial Transcript &gt;
-              (Dropdown) Report Type &gt; Unofficial Undergraduate
+              Quest</a> &rarr; My Academics &rarr; Unofficial Transcript &rarr;
+              (Dropdown) Report Type &rarr; Unofficial Undergraduate
           </p>
           <h3>Step 2</h3>
           <p class="step"> After your transcript loads, select the entire page


### PR DESCRIPTION
A small design change to use `&rarr;` instead of `&gt;`.

![](https://cloud.githubusercontent.com/assets/187822/5151809/9288ca5c-71b1-11e4-8f18-53a6867b3d35.png)

ps. A tiny-first-contribution to the project.
