### PR TITLE
Specify Gemfile versions to avoid conflicts

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 gem 'rdoc'
 gem 'bundle'
-gem 'compass'
-gem 'compass_twitter_bootstrap'
+gem 'compass', '0.12.2'
+gem 'compass_twitter_bootstrap', '2.0.3'
+gem 'sass', '3.2.3'


### PR DESCRIPTION
Even though compass installs Sass, the manual install will override it and install a compatible version instead. 

Thanks to @jlfwong for debugging and @younjin for the emotional support. 
