### PR TITLE
Changed margins to fit text on button

### DIFF
--- a/server/static/sass/_sign_in.scss
+++ b/server/static/sass/_sign_in.scss
@@ -49,7 +49,7 @@
   }
 
   .fb-login-text {
-    padding: 0 25px;
+    padding: 0 15px;
     font-weight: bold;
     font-size: 22px;
     color: white;


### PR DESCRIPTION
So for some reason the text wasn't fitting on the Facebook login button anymore, and it looks like this

![facebook_button](https://cloud.githubusercontent.com/assets/2644780/5160662/73942104-7360-11e4-8f2c-279954f3a525.png)

I just reduced the side-padding on the text, so it's fine now. I attached a screenshot below:

![fixed_facebook_button](https://cloud.githubusercontent.com/assets/2644780/5160659/33d88208-7360-11e4-86bc-1dc5f971d180.png)
