### PR TITLE
Removed 'bundle' from Gemfile since it is not needed

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 gem 'rdoc'
-gem 'bundle'
 gem 'compass', '0.12.2'
 gem 'compass_twitter_bootstrap', '2.0.3'
 gem 'sass', '3.2.3'


### PR DESCRIPTION
More info: https://github.com/will/bundle

Since bundler is used to install stuff in the Gemfile it doesn't make sense to install bundler within the Gemfile.