### PR TITLE
Delete all sections to prevent stale data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ data/exam_schedules/uw_exams_*
 data/departments/*.json
 data/opendata_sections/*.json
 data/opendata2_courses/*.json
+
+# Ignore generated js files
+server/static/js/scholarship.js
+server/static/js/.module-cache/

--- a/data/processor.py
+++ b/data/processor.py
@@ -576,6 +576,10 @@ def import_opendata_sections():
     filenames = glob.glob(os.path.join(os.path.dirname(__file__),
             c.SECTIONS_DATA_DIR, '*.json'))
 
+    # Delete all Sections to ensure we don't have stale sections
+    # See https://github.com/UWFlow/rmc/issues/255 for more details
+    m.Section.objects().delete()
+
     for filename in filenames:
         with open(filename, 'r') as f:
             data = json.load(f)

--- a/models/section.py
+++ b/models/section.py
@@ -108,6 +108,10 @@ class Section(me.Document):
 
     last_updated = me.DateTimeField()
 
+    # Uuid used to keep track of which sections were updated
+    # See https://github.com/UWFlow/rmc/issues/255 for more details
+    update_id = me.StringField()
+
     # TODO(david): Reserves info (we don't show this at the moment).
 
     # TODO(david): Do we want associated class crap


### PR DESCRIPTION
Fixes #255 

To ensure we don't have old sections that briefly appeared on the OpenData API, we can delete all our Sections and then add them back in.

We could also keep track of which sections were most recently updated, and remove the ones that weren't, but the number of sections is fairly minimal, so I'm not too worried about efficiency on this one. 