### PR TITLE
Use UTC time for section dates

### DIFF
--- a/server/templates/section.html
+++ b/server/templates/section.html
@@ -71,11 +71,11 @@
                 <% if (meeting.start_date) { %>
                   <span class="meeting-dates">
                     <% if (meeting.start_date.$date === meeting.end_date.$date) { %>
-                      (<%- moment(meeting.start_date.$date).format('MMM D') %>)
+                      (<%- moment.utc(meeting.start_date.$date).format('MMM D') %>)
                     <% } else { %>
-                      (<%- moment(meeting.start_date.$date).format('MMM D') %>
+                      (<%- moment.utc(meeting.start_date.$date).format('MMM D') %>
                       &ndash;
-                      <%- moment(meeting.end_date.$date).format('MMM D') %>)
+                      <%- moment.utc(meeting.end_date.$date).format('MMM D') %>)
                     <% } %>
                   </span>
                 <% } %>


### PR DESCRIPTION
So, not sure why we weren't using `moment.utc` before... but I think we should have always been using it. Also, this was probably always wrong, because all our dependencies are frozen and nothing should have changed.

Fixes #259 