### PR TITLE
Front end implementation for recommendations

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -120,6 +120,7 @@ class User(me.Document):
 
     # List of UserCourse.id's
     course_history = me.ListField(me.ObjectIdField())
+    recommended_courses = me.ListField(me.StringField())
 
     # TODO(mack): figure out why last_term_id was commented out in
     # a prior diff: #260f174

--- a/server/api/v1.py
+++ b/server/api/v1.py
@@ -507,8 +507,13 @@ def add_course_to_shortlist(course_id):
         raise api_util.ApiBadRequestError(
                 'Could not add course %s to shortlist. :(' % course_id)
 
+    # remove from recommendations if added to shortlist
+    if course_id in user.recommended_courses:
+        user.recommended_courses.remove(course_id)
+        user.save()
+
     return api_util.jsonify({
-        'user_course': user_course.to_dict(),
+        'user_course': user_course.to_dict()
     })
 
 # TODO(david): Add corresponding remove course endpoint

--- a/server/api/v1.py
+++ b/server/api/v1.py
@@ -513,10 +513,11 @@ def add_course_to_shortlist(course_id):
         user.save()
 
     return api_util.jsonify({
-        'user_course': user_course.to_dict()
+        'user_course': user_course.to_dict(),
     })
 
 # TODO(david): Add corresponding remove course endpoint
+
 
 @api.route('/user/rate_review_for_user', methods=['PUT'])
 def rate_review_for_user():
@@ -568,6 +569,7 @@ def rate_review_for_user():
         uc.save()
 
     return vote_added_response
+
 
 @api.route('/user/scholarships/<string:scholarship_id>', methods=['DELETE'])
 def remove_scholarship_from_profile(scholarship_id):

--- a/server/profile.py
+++ b/server/profile.py
@@ -453,6 +453,13 @@ def render_profile_page(profile_user_id, current_user=None):
                 s.id not in closed_scholarship_ids_set]
         scholarships_dict = [s.to_dict() for s in scholarships]
 
+    recommendation_dict = []
+    recommended_course_ids = []
+    if profile_user.id == current_user.id:
+        recommended_course_ids = current_user.recommended_courses
+        recommendation_dict = [m.Course.objects(id=course_id).first().to_dict()
+                               for course_id in recommended_course_ids]
+
     return flask.render_template('profile_page.html',
         page_script='profile_page.js',
         transcript_obj=ordered_transcript,
@@ -479,4 +486,6 @@ def render_profile_page(profile_user_id, current_user=None):
                 profile_user.has_schedule),
         course_id_to_review=course_id_to_review,
         scholarship_objs=scholarships_dict,
+        recommended_objs=recommendation_dict,
+        recommended_course_ids=recommended_course_ids,
     )

--- a/server/profile.py
+++ b/server/profile.py
@@ -487,5 +487,4 @@ def render_profile_page(profile_user_id, current_user=None):
         course_id_to_review=course_id_to_review,
         scholarship_objs=scholarships_dict,
         recommended_objs=recommendation_dict,
-        recommended_course_ids=recommended_course_ids,
     )

--- a/server/static/js/course.js
+++ b/server/static/js/course.js
@@ -397,6 +397,7 @@ function(RmcBackbone, $, _, _s, ratings, __, util, jqSlide, _prof, toastr,
     courseAdded: function() {
       this.updateRemoveCourseTooltip();
       this.render();
+      this.trigger('addedToShortlist', this.courseModel.id);
     },
 
     toggleCourse: function(evt) {
@@ -687,12 +688,18 @@ function(RmcBackbone, $, _, _s, ratings, __, util, jqSlide, _prof, toastr,
         'canShowAddReview' in attributes ? attributes.canShowAddReview : true;
     },
 
+    addToShortlist: function(course_id) {
+      this.trigger('addedToShortlist', course_id);
+    },
+
     addCourse: function(course) {
       var courseView = new CourseView({
         canShowAddReview: this.canShowAddReview,
         courseModel: course,
         tagName: 'li'
       });
+
+      courseView.bind('addedToShortlist', _.bind(this.addToShortlist, this));
       this.$el.append(courseView.render().el);
       this.courseViews.push(courseView);
     },

--- a/server/static/js/profile_page.js
+++ b/server/static/js/profile_page.js
@@ -110,8 +110,7 @@ function($, _, _s, _bootstrap, term, _course, friend, _util, user, _user_course,
     var recommendationView = new recommendation.RecommendationView({
       recommendationModel: recommendationModel
     });
-    recommendationView.bind('addedToShortlist',
-                            addToShortlist, this);
+    recommendationView.bind('addedToShortlist', addToShortlist, this);
     $('#recommendation-placeholder').replaceWith(
       recommendationView.render().el);
   };
@@ -142,10 +141,13 @@ function($, _, _s, _bootstrap, term, _course, friend, _util, user, _user_course,
   }
 
   // Render the recommendations, if available
-  var recommendedCourseIds = window.pageData.recommendedCourseIds;
   var recommendedObjs= window.pageData.recommendedObjs;
+  var recommendedCourseIds = _.map(recommendedObjs, function(course) {
+    return course.id;
+  });
+
   if (window.pageData.ownProfile &&
-      recommendedObjs && recommendedObjs.length !==0 &&
+      recommendedObjs && recommendedObjs.length !== 0 &&
       recommendedCourseIds && recommendedCourseIds.length !== 0) {
     _work_queue.add(function() {
       renderRecommendations(recommendedCourseIds);

--- a/server/static/js/profile_page.js
+++ b/server/static/js/profile_page.js
@@ -2,11 +2,12 @@ require(
 ['ext/jquery', 'ext/underscore', 'ext/underscore.string', 'ext/bootstrap',
 'term', 'course', 'friend', 'util', 'user', 'user_course', 'prof', 'exam',
 'raffle_unlock', 'schedule', 'sign_in', 'work_queue', 'scholarship',
-'ext/react'],
+'ext/react', 'recommendation'],
 function($, _, _s, _bootstrap, term, _course, friend, _util, user, _user_course,
   _prof, _exam, _raffle_unlock, _schedule, _sign_in, _work_queue,
-  _scholarship, React) {
+  _scholarship, React, recommendation) {
 
+  _course.CourseCollection.addToCache(pageData.recommendedObjs);
   _course.CourseCollection.addToCache(pageData.courseObjs);
   _user_course.UserCourses.addToCache(pageData.userCourseObjs);
   _prof.ProfCollection.addToCache(pageData.professorObjs);
@@ -90,6 +91,31 @@ function($, _, _s, _bootstrap, term, _course, friend, _util, user, _user_course,
     });
   }
 
+  var addToShortlist = function(course_id) {
+    if (this.profileTermsView) {
+      var course = _course.CourseCollection.getFromCache(course_id);
+      this.profileTermsView.addToShortlist(course);
+    }
+    else {
+      console.warn('Failed to render shortlist' +
+          'because the page did not load correctly');
+    }
+  };
+
+  var renderRecommendations = function(courseIds) {
+    var recommendationModel = new recommendation.RecommendationModel({
+      'course_ids': courseIds
+    });
+
+    var recommendationView = new recommendation.RecommendationView({
+      recommendationModel: recommendationModel
+    });
+    recommendationView.bind('addedToShortlist',
+                            addToShortlist, this);
+    $('#recommendation-placeholder').replaceWith(
+      recommendationView.render().el);
+  };
+
   var renderTranscript = function(transcriptObj) {
     var termCollection = new term.TermCollection();
 
@@ -99,11 +125,12 @@ function($, _, _s, _bootstrap, term, _course, friend, _util, user, _user_course,
     });
 
     // Add the parsed term and course info to the page for live preview
-    var profileTermsView = new term.ProfileTermsView({
+    this.profileTermsView = new term.ProfileTermsView({
       termCollection: termCollection,
       showAddTerm: window.pageData.ownProfile
     });
-    $('#profile-terms-placeholder').replaceWith(profileTermsView.render().el);
+    $('#profile-terms-placeholder').replaceWith(
+      this.profileTermsView.render().el);
   };
 
   // Render the transcript, if available
@@ -111,6 +138,17 @@ function($, _, _s, _bootstrap, term, _course, friend, _util, user, _user_course,
   if (transcriptObj && transcriptObj.length !== 0) {
     _work_queue.add(function() {
       renderTranscript(transcriptObj);
+    });
+  }
+
+  // Render the recommendations, if available
+  var recommendedCourseIds = window.pageData.recommendedCourseIds;
+  var recommendedObjs= window.pageData.recommendedObjs;
+  if (window.pageData.ownProfile &&
+      recommendedObjs && recommendedObjs.length !==0 &&
+      recommendedCourseIds && recommendedCourseIds.length !== 0) {
+    _work_queue.add(function() {
+      renderRecommendations(recommendedCourseIds);
     });
   }
 

--- a/server/static/js/recommendation.js
+++ b/server/static/js/recommendation.js
@@ -1,0 +1,51 @@
+define(
+['rmc_backbone', 'ext/underscore', 'ext/jquery', 'course'],
+function(RmcBackbone, _, $, _course) {
+
+  var RecommendationModel = RmcBackbone.Model.extend({
+    defaults: {
+      'course_ids': []
+    },
+    
+    referenceFields: {
+      'courses': ['course_ids', _course.CourseCollection]
+    }
+  });
+
+
+  var RecommendationView = RmcBackbone.View.extend({
+    className: 'recommendation',
+    
+    initialize: function(options) {
+      this.recommendationModel = options.recommendationModel;
+      this.courses = this.recommendationModel.get('courses');
+      this.courseCollectionView = new _course.CourseCollectionView({
+        courses: this.courses,
+        canShowAddReview: pageData.ownProfile
+      });
+      this.courseCollectionView.bind('addedToShortlist',
+                                     this.removeCourse, this);
+      this.template =_.template($('#recommendation-tpl').html());
+      
+    },
+
+    removeCourse: function(course_id) {
+      this.courses.remove(_course.CourseCollection.getFromCache(course_id));
+      this.render();
+      this.trigger('addedToShortlist', course_id);
+    },
+
+    render: function(options) {
+      this.num_courses = this.courses.length;
+      this.$el.html(this.template({'num_courses': this.num_courses}));
+      this.$el.find('.course-collection-placeholder').replaceWith(
+          this.courseCollectionView.render().el);
+      return this;
+    }
+  });
+
+  return {
+    RecommendationView: RecommendationView,
+    RecommendationModel: RecommendationModel
+  };
+});

--- a/server/static/js/term.js
+++ b/server/static/js/term.js
@@ -54,6 +54,10 @@ function(RmcBackbone, _, $, _course, jqSlide, _user_course, _util) {
       return this;
     },
 
+    addCourse: function(course) {
+      this.courseCollectionView.addCourse(course);
+    },
+
     getTermExpandedKey: function() {
       return 'termExpanded:' + this.termModel.get('id');
     },
@@ -128,6 +132,22 @@ function(RmcBackbone, _, $, _course, jqSlide, _user_course, _util) {
       }, this);
 
       return this;
+    },
+
+    addTerm: function(term) {
+      var termView = new TermView({
+        termModel: term,
+        tagName: 'li',
+        expand: true
+      });
+      this.$el.prepend(termView.render().el);
+      this.termViews.push(termView);
+    },
+
+    get: function(term_id) {
+      return this.termViews.find(function(term) {
+        return term.termModel.id === term_id;
+      });
     }
   });
 
@@ -164,6 +184,22 @@ function(RmcBackbone, _, $, _course, jqSlide, _user_course, _util) {
       }
 
       this.template = _.template($('#profile-terms-tpl').html());
+    },
+
+    addToShortlist: function(course) {
+      var term = this.termCollectionView.get('9999_99');
+      if (!term) {
+        // make shortlist if it does not exist
+        var shortlistModel = new TermModel({
+          'course_ids': [],
+          'program_year_id': 'None',
+          'id': '9999_99',
+          'name': 'Shortlist'
+        });
+        this.termCollectionView.addTerm(shortlistModel);
+        term = this.termCollectionView.get('9999_99');
+      }
+      term.addCourse(course, '9999_99');
     },
 
     events: {

--- a/server/static/sass/_course.scss
+++ b/server/static/sass/_course.scss
@@ -374,3 +374,11 @@ $inner-padding: 18px;
     border-top: 1px solid #DDD;
   }
 }
+
+.recommendation .course .course-content {
+  margin-left: 0px
+}
+
+.recommendation .course .shortlist-btn {
+  margin-left: -35px
+}

--- a/server/templates/profile_page.html
+++ b/server/templates/profile_page.html
@@ -66,6 +66,7 @@
   <div id="schedule-input-modal-placeholder"></div>
   <div id="class-schedule-placeholder"></div>
   <div id="exam-schedule-placeholder"></div>
+  <div id="recommendation-placeholder"></div>
   <div id="profile-terms-placeholder"></div>
   <div id="scholarship-placeholder"></div>
 
@@ -81,6 +82,7 @@
   {% include 'exam.html' %}
   {% include 'schedule.html' %}
   {% include 'sign_in.html' %}
+  {% include 'recommendation.html' %}
 {% endblock %}
 
 {% block scripts %}
@@ -102,5 +104,7 @@
   window.pageData.courseIdToReview = {{ course_id_to_review|tojson|safe }};
   window.pageData.profileUserSecretId = {{ profile_user_secret_id|tojson|safe }};
   window.pageData.scholarshipObjs = {{ scholarship_objs|tojson|safe }};
+  window.pageData.recommendedObjs= {{ recommended_objs|tojson|safe }};
+  window.pageData.recommendedCourseIds= {{ recommended_course_ids|tojson|safe }};
 </script>
 {% endblock %}

--- a/server/templates/profile_page.html
+++ b/server/templates/profile_page.html
@@ -105,6 +105,5 @@
   window.pageData.profileUserSecretId = {{ profile_user_secret_id|tojson|safe }};
   window.pageData.scholarshipObjs = {{ scholarship_objs|tojson|safe }};
   window.pageData.recommendedObjs= {{ recommended_objs|tojson|safe }};
-  window.pageData.recommendedCourseIds= {{ recommended_course_ids|tojson|safe }};
 </script>
 {% endblock %}

--- a/server/templates/recommendation.html
+++ b/server/templates/recommendation.html
@@ -1,0 +1,8 @@
+{% import 'macros.html' as macros %}
+
+{% call macros.us_template('recommendation-tpl') %}
+<% if (num_courses) { %>
+<h1>Courses you may be interested in</h1>
+<div class="course-collection-placeholder"></div>
+<% } %>
+{% endcall %}


### PR DESCRIPTION
I decided to separate the front-end portion of the recommender system as another pull request. I believe the two pull requests are independent of one another and can be deployed separately.

![frontend](https://cloud.githubusercontent.com/assets/6456601/12370697/969284bc-bbe8-11e5-83ef-db1ebb4a2473.jpg)
Per @david12 request, I moved the recommendation view to the bottom of the calender. It currently shows at most 3 recommendation. 

* If you add a recommendation to your shortlist, it will be automatically removed from the recommendations and added to the shortlist.

* If you add the a recommendation to your shortlist, your recommendations will be removed from the database and not be shown again (unless if the engine is retrained). 

* If you have zero recommendations, then the text "Courses you might be interested in" will also be removed.

* The courses for the recommendations follow the exact same template and behaviour as the rest of the courses.

* Someone with access to the friends graph should test the recommendations do not show up in a friend's profile, as I cannot test this scenario with my local database.

To run this feature, checkout https://github.com/UWFlow/rmc/pull/254 and run ```make train_engine``` to save the recommendations to every user, then it should work as expected.