### PR TITLE
updated version of uWSGI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ lxml==2.3.5
 pep8==1.0.1
 pyflakes==0.7.3
 pymongo==2.3
-uWSGI==1.9.9
+uWSGI==2.0.14
 mongoengine==0.7.5
 redis==2.6.2
 hiredis==0.1.1


### PR DESCRIPTION
Fix for 'make install' error:

Failed building wheel for uWSGI
Failed to build uWSGI
Running setup.py install for uWSGI
Complete output from command /Users/shaoyuliang/xiaohongshu/gitlab/.virtualenvs/fulishe/bin/python -c "import setuptools, tokenize;file='/private/var/folders/pk/qsqn5vts05l94tyhthvn7qrw0000gn/T/pip-build-mqcl87/uWSGI/setup.py';exec(compile(getattr(tokenize, 'open', open)(file).read().replace('\r\n', '\n'), file, 'exec'))" install --record /var/folders/pk/qsqn5vts05l94tyhthvn7qrw0000gn/T/pip-mgEkBs-record/install-record.txt --single-version-externally-managed --compile --install-headers /Users/shaoyuliang/xiaohongshu/gitlab/.virtualenvs/fulishe/include/site/python2.7/uWSGI:
running install
core/socket.c:708:28: error: use of undeclared identifier 'SOL_TCP'
if (setsockopt(serverfd, SOL_TCP, TCP_FASTOPEN, (const void *) &uwsgi.tcp_fast_open, sizeof(int)) < 0) {
^
1 error generated.
