### PR TITLE
Remove unused CritiqueCourse document

### DIFF
--- a/data/aggregator.py
+++ b/data/aggregator.py
@@ -107,9 +107,6 @@ def update_mongo_course_rating():
 
     increment_ratings(*(args + [get_fields_fn, menlo_ucs]))
     increment_ratings(*(args + [get_fields_fn, flow_ucs]))
-    # TODO(mack): add back course critiques
-    # increment_aggregate_ratings(*(args + [get_aggregate_fields_fn,
-    #                                       m.CritiqueCourse.objects]))
 
     count = [0]
 
@@ -193,8 +190,6 @@ def update_redis_course_professor_rating():
 
     increment_ratings(*(args + [get_fields_fn, menlo_ucs]))
     increment_ratings(*(args + [get_fields_fn, flow_ucs]))
-    increment_aggregate_ratings(*(args + [get_aggregate_fields_fn,
-                                          m.CritiqueCourse.objects]))
 
     count = [0]
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -12,7 +12,6 @@ from term import Term  # @UnusedImport
 from user import User  # @UnusedImport
 from user_course import MenloCourse  # @UnusedImport
 from user_course import UserCourse  # @UnusedImport
-from user_course import CritiqueCourse  # @UnusedImport
 from section import SectionMeeting  # @UnusedImport
 from section import Section  # @UnusedImport
 from course_alert import BaseCourseAlert  # @UnusedImport

--- a/models/user_course.py
+++ b/models/user_course.py
@@ -6,7 +6,6 @@ import mongoengine as me
 import course
 import points as _points
 import professor
-import rating
 import review
 import rmc.shared.util as util
 import term
@@ -28,37 +27,6 @@ def get_user_course_modified_date(uc):
         date = valid_dates[0]
 
     return date
-
-
-class CritiqueCourse(me.Document):
-    meta = {
-        'indexes': [
-            'course_id',
-            'professor_id',
-        ],
-    }
-
-    # id = me.ObjectIdField(primary_key=True)
-
-    course_id = me.StringField(required=True)
-    # TODO(mack): need section_id or equiv
-    # course_id = me.StringField(required=True, unique_with='section_id')
-    # section_id = me.IntField(required=True)
-    professor_id = me.StringField(required=True)
-    term_id = me.StringField(required=True)
-
-    interest = me.EmbeddedDocumentField(rating.AggregateRating,
-                                        default=rating.AggregateRating())
-    easiness = me.EmbeddedDocumentField(rating.AggregateRating,
-                                        default=rating.AggregateRating())
-    overall_course = me.EmbeddedDocumentField(rating.AggregateRating,
-                                              default=rating.AggregateRating())
-    clarity = me.EmbeddedDocumentField(rating.AggregateRating,
-                                       default=rating.AggregateRating())
-    passion = me.EmbeddedDocumentField(rating.AggregateRating,
-                                       default=rating.AggregateRating())
-    overall_prof = me.EmbeddedDocumentField(rating.AggregateRating,
-                                            default=rating.AggregateRating())
 
 
 class MenloCourse(me.Document):


### PR DESCRIPTION
Looking through the various models and trying to provide better documentation on what they're each for, this one popped up and seems to be unused. There are currently no `CritiqueCourse` objects in the production db, so it shouldn't affect anything.