### PR TITLE
Changing course catalog url to work for graduate level courses

### DIFF
--- a/server/templates/section.html
+++ b/server/templates/section.html
@@ -120,8 +120,9 @@
 
     <% var courseParts = splitCourseId(term[0].get('course_id')); %>
     <% var questId = termIdToQuestId(termId); %>
+    <% var courseLevel = (courseParts[1] <= 499) ? 'under' : 'grad'; %>
 
-    <a href="http://www.adm.uwaterloo.ca/cgi-bin/cgiwrap/infocour/salook.pl?level=under&sess=<%- questId %>&subject=<%- courseParts[0] %>&cournum=<%- courseParts[1] %>"
+    <a href="http://www.adm.uwaterloo.ca/cgi-bin/cgiwrap/infocour/salook.pl?level=<%- courseLevel %>&sess=<%- questId %>&subject=<%- courseParts[0] %>&cournum=<%- courseParts[1] %>"
         target="_blank">
       www.adm.uwaterloo.ca</a>.
    </small>


### PR DESCRIPTION
For example: https://uwflow.com/course/cs684
<img width="1013" alt="screen shot 2018-08-07 at 2 06 58 am" src="https://user-images.githubusercontent.com/5900467/43757383-a2fb9534-99e6-11e8-85f3-f4a71d501785.png">

Clicking on the link 'www.adm.uwaterloo.ca' takes it to http://www.adm.uwaterloo.ca/cgi-bin/cgiwrap/infocour/salook.pl?level=under&sess=1189&subject=CS&cournum=684

level should be 'grad' for the link to work: http://www.adm.uwaterloo.ca/cgi-bin/cgiwrap/infocour/salook.pl?level=grad&sess=1189&subject=CS&cournum=684