### PR TITLE
Support instructors without commas in their names

### DIFF
--- a/data/processor.py
+++ b/data/processor.py
@@ -511,7 +511,12 @@ def _opendata_to_section_meeting(data, term_year):
     )
 
     if data['instructors']:
-        last_name, first_name = data['instructors'][0].split(',')
+        names = data['instructors'][0].split(',')
+        if len(names) == 2:
+            last_name, first_name = names
+        else:
+            last_name = names[0]
+            first_name = ''
         prof_id = m.Professor.get_id_from_name(first_name, last_name)
         if not m.Professor.objects.with_id(prof_id):
             m.Professor(id=prof_id, first_name=first_name,


### PR DESCRIPTION
It looks like open data (and adm) incorrectly displays one of the instructors for [FR192A](https://uwflow.com/course/fr192a) this semester, only displaying their last name. This led to the data processor throwing an exception, which is probably why the website stopped updating at the beginning of this term (#328).

The attached pull request gives a quick workaround. Using this workaround, l was able to crawl this and next term's sections.

For a slightly better work around, we could hard code their first name based on their last name, and hope this problem doesn't happen again. If we want a permanent work-around, the best source for first names I could find is the UW white pages, which isn't very crawling-friendly.