### PR TITLE
Fix local server bringup

### DIFF
--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -31,12 +31,12 @@ install_packages() {
     fi
 
     # To get the most recent redis-server
-    wget http://download.redis.io/redis-stable.tar.gz
-    tar xvzf redis-stable.tar.gz
-    cd redis-stable
+    wget http://download.redis.io/releases/redis-2.6.17.tar.gz
+    tar xvzf redis-2.6.17.tar.gz
+    cd redis-2.6.17
     sudo make install
     cd ..
-    sudo rm -rf redis-stable
+    sudo rm -rf redis-2.6.17
 
     # To get the most recent mongodb
     if ! ls /etc/apt/sources.list.d/ 2>&1 | grep -q 10gen; then

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -30,14 +30,6 @@ install_packages() {
         updated_apt_repo=yes
     fi
 
-    # To get the most recent redis-server
-    wget http://download.redis.io/releases/redis-2.6.17.tar.gz
-    tar xvzf redis-2.6.17.tar.gz
-    cd redis-2.6.17
-    sudo make install
-    cd ..
-    sudo rm -rf redis-2.6.17
-
     # To get the most recent mongodb
     if ! ls /etc/apt/sources.list.d/ 2>&1 | grep -q 10gen; then
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
-gem 'rdoc'
-gem 'bundle'
+gem 'rdoc', '4.3.0'
+gem 'bundler', '1.11.2'
 gem 'compass', '0.12.2'
 gem 'compass_twitter_bootstrap', '2.0.3'
 gem 'sass', '3.2.3'

--- a/server_setup/setup.sh
+++ b/server_setup/setup.sh
@@ -114,8 +114,8 @@ sudo apt-get install -y libxml2-dev libxslt-dev
 gem install compass
 ( cd $HOME/rmc/server && compass init --config config.rb )
 # Setup bundle
-gem install rdoc
-gem install bundle
+gem install rdoc -v 4.2.0
+gem install bundler -v 1.11.2
 gem install rdoc-data; rdoc-data --install
 ( cd $HOME/rmc/server && bundle install )
 # Install pip requirements

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@ install_gems() {
     if ! which bundle >/dev/null 2>&1; then
         # Ruby stuffs: Install bundler so we can grab other gems
         echo "Installing bundler"
-        sudo gem install bundler
+        sudo gem install bundler -v 1.11.2
     fi
 
     echo "Installing gems"


### PR DESCRIPTION
This contains two changes which, in combination, make dev server bringup error-free.

1. Building the latest version of Redis from source has been breaking Celery for a while, as noted in #286. Interestingly, not far below the region removed in this PR, `redis-server` is installed via `apt` anyway. As Trusty is still supported (if not for long), it seems reasonable to just avoid the manual build entirely. To test that (1) works, `dshynkev/uwflow:latest` from DockerHub can be used.

2. For (1) to take effect, the image `docker_shell.sh` uses has to be rebuilt. If one were to attempt this in the current state, the build would fail: non-version-pinned gems ask for a newer `ruby`. This is addressed here as well as an auxiliary fix.