### PR TITLE
[FLOW-7] Issue #274: Fixed Google Calendar export

### DIFF
--- a/server/static/js/schedule.js
+++ b/server/static/js/schedule.js
@@ -444,7 +444,7 @@ function(RmcBackbone, $, _, _s, _bootstrap, _user, _course, _util, _facebook,
         start_date: this.schedule.get('start_date'),
         end_date: this.schedule.get('end_date'),
         total_hours: this.calculateHoursPerWeek(this.schedule),
-        
+
         // TODO(david): Only show for appropriate term
         courses_not_shown: this.schedule.get('courses_not_shown')
       }));
@@ -861,7 +861,7 @@ function(RmcBackbone, $, _, _s, _bootstrap, _user, _course, _util, _facebook,
   };
 
   var getICalScheduleUrl = function() {
-    var baseURL = _util.getSiteBaseUrl().replace('https', 'http');
+    var baseURL = _util.getSiteBaseUrl().replace('webcal', 'http');
 
     return baseURL +
         '/schedule/ical/' + window.pageData.profileUserSecretId + '.ics';

--- a/server/static/js/schedule.js
+++ b/server/static/js/schedule.js
@@ -444,7 +444,7 @@ function(RmcBackbone, $, _, _s, _bootstrap, _user, _course, _util, _facebook,
         start_date: this.schedule.get('start_date'),
         end_date: this.schedule.get('end_date'),
         total_hours: this.calculateHoursPerWeek(this.schedule),
-
+        
         // TODO(david): Only show for appropriate term
         courses_not_shown: this.schedule.get('courses_not_shown')
       }));
@@ -861,7 +861,7 @@ function(RmcBackbone, $, _, _s, _bootstrap, _user, _course, _util, _facebook,
   };
 
   var getICalScheduleUrl = function() {
-    var baseURL = _util.getSiteBaseUrl().replace('webcal', 'http');
+    var baseURL = _util.getSiteBaseUrl().replace('https', 'webcal');
 
     return baseURL +
         '/schedule/ical/' + window.pageData.profileUserSecretId + '.ics';

--- a/server/static/js/schedule.js
+++ b/server/static/js/schedule.js
@@ -444,7 +444,7 @@ function(RmcBackbone, $, _, _s, _bootstrap, _user, _course, _util, _facebook,
         start_date: this.schedule.get('start_date'),
         end_date: this.schedule.get('end_date'),
         total_hours: this.calculateHoursPerWeek(this.schedule),
-        
+
         // TODO(david): Only show for appropriate term
         courses_not_shown: this.schedule.get('courses_not_shown')
       }));
@@ -861,7 +861,7 @@ function(RmcBackbone, $, _, _s, _bootstrap, _user, _course, _util, _facebook,
   };
 
   var getICalScheduleUrl = function() {
-    var baseURL = _util.getSiteBaseUrl().replace('https', 'webcal');
+    var baseURL = _util.getSiteBaseUrl().replace('https', 'webcal').replace('uwflow', 'www.uwflow');
 
     return baseURL +
         '/schedule/ical/' + window.pageData.profileUserSecretId + '.ics';


### PR DESCRIPTION
From #274 . Previously only initial export to GCal worked. Subsequent exports would not update GCal with new changes to calendar. Small change from http to webcal protocol fixes the icalendar import. Ex:

Old link: https://calendar.google.com/calendar/r?cid=http://uwflow.com/schedule/ical/5P660SWH2.ics
New link: https://calendar.google.com/calendar/r?cid=webcal://www.uwflow.com/schedule/ical/5P660SWH2.ics