### PR TITLE
Do not duplicate courses and professors in localStorage

### DIFF
--- a/server/static/js/search_bar.js
+++ b/server/static/js/search_bar.js
@@ -50,8 +50,8 @@ function(RmcBackbone, $, _, _util, _typeahead) {
     var engine = new Bloodhound({
       name: 'friendsAndCourses',
       local: [].concat(_util.getLocalData('friends'),
-          _util.getLocalData('courses'),
-          _util.getLocalData('professors')),
+          _util.getLocalData('courses', false),
+          _util.getLocalData('professors', false)),
       datumTokenizer: function(d) {
         return Bloodhound.tokenizers.whitespace(d.tokens.join(' '));
       },
@@ -125,13 +125,13 @@ function(RmcBackbone, $, _, _util, _typeahead) {
     getData: function() {
       var self = this;
       var resultTypes = [];
-      if (!_util.getLocalData('courses')) {
+      if (!_util.getLocalData('courses', false)) {
         resultTypes.push('courses');
       }
       if (!_util.getLocalData('friends')) {
         resultTypes.push('friends');
       }
-      if (!_util.getLocalData('professors')) {
+      if (!_util.getLocalData('professors', false)) {
         resultTypes.push('professors');
       }
       resultTypes.join(',');
@@ -141,16 +141,18 @@ function(RmcBackbone, $, _, _util, _typeahead) {
           url: '/api/v1/search/unified?result_types=' + resultTypes,
           success: function(data) {
             if (resultTypes.indexOf('courses') >= 0) {
+              _util.clearLocalData('|courses');  // Delete old user-bound data
               _util.storeLocalData('courses', data.courses,
-                  +(new Date()) + 1000 * 60 * 60 * 24 * 14);
+                  +(new Date()) + 1000 * 60 * 60 * 24 * 14, false);
             }
             if (resultTypes.indexOf('friends') >= 0) {
               _util.storeLocalData('friends', data.friends,
                   +(new Date()) + 1000 * 60 * 60 * 24);
             }
             if (resultTypes.indexOf('professors') >= 0) {
+              _util.clearLocalData('|professors');  // Delete old user-bound data
               _util.storeLocalData('professors', data.professors,
-                  +(new Date()) + 1000 * 60 * 60 * 24 * 28);
+                  +(new Date()) + 1000 * 60 * 60 * 24 * 28, false);
             }
             initBloodhoundWithAutocomplete(self);
           }

--- a/server/static/js/util.js
+++ b/server/static/js/util.js
@@ -172,7 +172,7 @@ function(_, _s, $) {
    * @param {Date|number} expiration Optional: Date which this key-value should
    *     expire (a call to get will return null/undefined).
    */
-  var storeLocalData = function(key, value, expiration) {
+  var storeLocalData = function(key, value, expiration, userBound = true) {
     if (!window.localStorage) {
       return;
     }
@@ -182,18 +182,18 @@ function(_, _s, $) {
       data.exp = +expiration;  // Store timestamp as number
     }
     var userId = getCurrentUserId() || '';
-    window.localStorage[userId + '|' + key] = JSON.stringify(data);
+    window.localStorage[userBound ? (userId + '|' + key) : key] = JSON.stringify(data);
   };
 
   /**
    * Retrieve data from localStorage associated with the current user.
    */
-  var getLocalData = function(key) {
+  var getLocalData = function(key, userBound = true) {
     if (!window.localStorage) {
       return;
     }
     var userId = getCurrentUserId() || '';
-    var userKey = userId + '|' + key;
+    var userKey = userBound ? (userId + '|' + key) : key;
     var data = window.localStorage[userKey];
 
     if (data != null) {
@@ -211,6 +211,20 @@ function(_, _s, $) {
     // Handle older formats that were just the unwrapped JSON-encoded value.
     return (_.isObject(data) && 'val' in data) ? data.val : data;
   };
+
+  /*
+  ** Delete keys _containing_ a given substring from localStorage.
+  */
+  var clearLocalData = function(search) {
+    if (!window.localStorage) {
+      return;
+    }
+    for (var key in window.localStorage) {
+      if (key.indexOf(search) >= 0) {
+        delete window.localStorage[key];
+      }
+    }
+  }
 
   var scrollToElementId = function(id) {
     // Compensate for nav bar height
@@ -368,6 +382,7 @@ function(_, _s, $) {
     getReferrerId: getReferrerId,
     storeLocalData: storeLocalData,
     getLocalData: getLocalData,
+    clearLocalData: clearLocalData,
     scrollToElementId: scrollToElementId,
     humanizeTermId: humanizeTermId,
     humanizeProfId: humanizeProfId,


### PR DESCRIPTION
`localStorage` may run out of space due to `courses` and `professors` being duplicated under `|{key}` and `{userId}|{key}` if the user tries searching before logging in. This will cause search to break.

This change disassociates said keys from user identity and ensures the old user-bound copies are deleted from `localStorage`, so that the new unified copy may have space to be stored.