### PR TITLE
Add PRODID and VERSION to .ics exports

### DIFF
--- a/server/profile.py
+++ b/server/profile.py
@@ -89,6 +89,9 @@ def render_schedule_ical_feed(profile_user_secret_id):
     course_name_map = {c['id']: c['name'] for c in limited_course_list}
 
     cal = icalendar.Calendar()
+    # The following two properties are *required* to be conformant
+    cal.add('version', '2.0')
+    cal.add('prodid', '-//UW FLOW//%s//EN' % profile_user_secret_id)
     cal.add('x-wr-calname', 'uwflow.com schedule')
     cal.add('x-wr-caldesc', 'Schedule exported from https://uwflow.com')
 


### PR DESCRIPTION
This change is needed to conform to [RFC 5545](https://tools.ietf.org/html/rfc5545), which requires:

> Property Name: `PRODID`
> Conformance:  The property MUST be specified once in an iCalendar object.

> Property Name: `VERSION`
> Conformance:  This property MUST be specified once in an iCalendar object.

My hope is that this is also what caused #343, but I do not have access to iCal to check.