### PR TITLE
Do not add www. in webcal: link

### DIFF
--- a/server/static/js/schedule.js
+++ b/server/static/js/schedule.js
@@ -861,7 +861,7 @@ function(RmcBackbone, $, _, _s, _bootstrap, _user, _course, _util, _facebook,
   };
 
   var getICalScheduleUrl = function() {
-    var baseURL = _util.getSiteBaseUrl().replace('https', 'webcal').replace('uwflow', 'www.uwflow');
+    var baseURL = _util.getSiteBaseUrl().replace('https', 'webcal');
 
     return baseURL +
         '/schedule/ical/' + window.pageData.profileUserSecretId + '.ics';


### PR DESCRIPTION
Our certificate is not valid for `www.uwflow.com` (known issue: #320). As a result, `webcal:` links that reference that hostname will not work if the client enforces proper security, like Apple Calendar seems to do. This is likely the cause of #343 and similar reports. Stripping off the `www.` prefix fixes the issue in Apple Calendar in my testing. Of course, we should eventually take care of the certificate issue as well.