### PR TITLE
Fix/flow 43 calendar export

### DIFF
--- a/server/static/js/schedule.js
+++ b/server/static/js/schedule.js
@@ -862,9 +862,11 @@ function(RmcBackbone, $, _, _s, _bootstrap, _user, _course, _util, _facebook,
 
   var getICalScheduleUrl = function() {
     var baseURL = _util.getSiteBaseUrl().replace('https', 'webcal');
+    var d = new Date();
 
     return baseURL +
-        '/schedule/ical/' + window.pageData.profileUserSecretId + '.ics';
+        '/schedule/ical/' + window.pageData.profileUserSecretId +
+        '.ics?noCache-' + d.getTime();
   };
 
   return {

--- a/server/static/js/schedule.js
+++ b/server/static/js/schedule.js
@@ -866,7 +866,7 @@ function(RmcBackbone, $, _, _s, _bootstrap, _user, _course, _util, _facebook,
 
     return baseURL +
         '/schedule/ical/' + window.pageData.profileUserSecretId +
-        '.ics?noCache-' + d.getTime();
+        '.ics?noCache=' + d.getTime();
   };
 
   return {


### PR DESCRIPTION
This commit resolves FLOW-43 by appending a UNIX timestamp to each generated calendar. This forces calendar applications to treat every Flow calendar as a new one, bypassing caching.
All unit tests pass on this fix.

@bobqywei @dshynkev 