### PR TITLE
Support OpenSearch

### DIFF
--- a/server/static/opensearch/opensearch.xml
+++ b/server/static/opensearch/opensearch.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+	<ShortName>UW Flow</ShortName>
+	<Description>Search UW's course catalog</Description>
+	<Url type="application/rss+xml" template="https://uwflow.com/explore?q={searchTerms}"/>
+</OpenSearchDescription>

--- a/server/static/opensearch/opensearch.xml
+++ b/server/static/opensearch/opensearch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
 	<ShortName>UW Flow</ShortName>
-	<Description>Search UW's course catalog</Description>
+	<Description>Search UW Flow</Description>
 	<Url type="application/rss+xml" template="https://uwflow.com/explore?q={searchTerms}"/>
 </OpenSearchDescription>

--- a/server/templates/base_page.html
+++ b/server/templates/base_page.html
@@ -19,7 +19,7 @@
     <meta property="og:description" content="Plan your UW courses with friends in mind.">
     <meta property="og:image" content="https://uwflow.com/static/img/logo/flow_og_200x200.png">
     <meta content="{{ csrf_token() }}" name="csrf-token" />
-    <link rel="search" type="application/opensearchdescription+xml" title="Search Perishable Press" href="/static/opensearch/opensearch.xml" />
+    <link rel="search" type="application/opensearchdescription+xml" title="Search UW Flow" href="/static/opensearch/opensearch.xml" />
     {% block head_tags %}
     {% endblock %}
 

--- a/server/templates/base_page.html
+++ b/server/templates/base_page.html
@@ -19,6 +19,7 @@
     <meta property="og:description" content="Plan your UW courses with friends in mind.">
     <meta property="og:image" content="https://uwflow.com/static/img/logo/flow_og_200x200.png">
     <meta content="{{ csrf_token() }}" name="csrf-token" />
+    <link rel="search" type="application/opensearchdescription+xml" title="Search Perishable Press" href="/static/opensearch/opensearch.xml" />
     {% block head_tags %}
     {% endblock %}
 


### PR DESCRIPTION
This PR introduces a minor change to support open search (followed this guide - https://perishablepress.com/custom-opensearch-functionality-for-your-website/).

This allows for chrome and other browsers to directly search UW Flow.

Unfortunately, I wasn't able to compile the project locally (Installing docker on windows seems to be more complicated than I though), hoping a maintainer could quickly verify this patch locally for me :)